### PR TITLE
[CircleCI] Fix release job dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,10 @@ jobs:
 workflows:
   main:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              only: /.*/
 
       - release:
           requires:


### PR DESCRIPTION
We're missing a dependency in the tags filter of the workflow. The `release` job depends on the `build` job and only runs when a tag is pushed. Therefore, the `build` job needs a filter for tags in order to kick off the workflow.

Docs: https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag