### PR TITLE
[CircleCI] Fix NPM issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
 
       - node/install:
           node-version: '16.0.0'
-          install-npm: true
+          install-npm: false
           install-yarn: true
           yarn-version: '1.22.5'
 


### PR DESCRIPTION
We cannot install NPM with the `circleci/node` orb if we're using a Node image. Since the image already has NPM installed, the orb step fails