### PR TITLE
fix(release): NPM issue with whitelist format

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -12,11 +12,11 @@ Then, you need to run:
 ```
 yarn pack
 ```
-This will generate a `stackbuilders-react-native-spotlight-tour-<version>\.tgz` file. This will be used by the example as a package. Inside the `/example` directory, you could check the `dependencies` section of the `package.json` file to verify this. 
+This will generate a `stackbuilders-react-native-spotlight-tour-v0.0.0.tgz` file. This will be used by the example as a package. Inside the `/example` directory, you could check the `dependencies` section of the `package.json` file to verify this. 
 
 If the library is not referenced, add it with the following command:
 ```
-yarn add ../stackbuilders-react-native-spotlight-tour-<version>\.tgz
+yarn add ../stackbuilders-react-native-spotlight-tour-v0.0.0.tgz
 ```
 
 Finally, in the `/example` directory, you need to run: 

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@cometlib/dedent": "^0.8.0-es.10",
-    "@stackbuilders/react-native-spotlight-tour": "../stackbuilders-react-native-spotlight-tour-v0.1.0.tgz",
+    "@stackbuilders/react-native-spotlight-tour": "../stackbuilders-react-native-spotlight-tour-v0.0.0.tgz",
     "react": "17.0.1",
     "react-native": "0.64.0",
     "react-native-svg": "^12.1.1",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "types": "./dist/index.d.ts",
   "react-native": "./src/index.ts",
   "files": [
-    "./dist",
-    "./src"
+    "dist/",
+    "src/"
   ],
   "scripts": {
     "compile": "tsc",


### PR DESCRIPTION
In the file whitelist, NPM will not recognize the format `./dist/`, so we need to change it to `dist/`