### PR TITLE
chore(example): Fix gradlew.bat line ending

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -36,3 +36,7 @@ allprojects {
         maven { url 'https://www.jitpack.io' }
     }
 }
+
+wrapper {
+    distributionType = "all"
+}


### PR DESCRIPTION
This PR pushes the file `gradlew.bat` of the sample with the correct line ending for Windows files (CRLF). In addition, I added a change in the `build.gradle` file to preserve the distribution the of the Gradle Wrapper whenever we update/change it 🙂 