### PR TITLE
Rectangular customizable spotlight, fading animation, touchable backdrop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { AttachStep } from "./lib/AttachStep.component";
-export { Align, Position, RenderProps, SpotlightTour, TourStep, useSpotlightTour } from "./lib/SpotlightTour.context";
+export { Align, Position, Shape, RenderProps, SpotlightTour, TourStep, useSpotlightTour } from "./lib/SpotlightTour.context";
 export { SpotlightTourProvider } from "./lib/SpotlightTour.provider";
 export { TourBox } from "./lib/tour-box/TourBox.component";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { AttachStep } from "./lib/AttachStep.component";
-export { Align, Position, Shape, RenderProps, SpotlightTour, TourStep, useSpotlightTour } from "./lib/SpotlightTour.context";
+export { Align, Position, Shape, Motion, RectangleProps, RenderProps, SpotlightTour, TourStep, useSpotlightTour } from "./lib/SpotlightTour.context";
 export { SpotlightTourProvider } from "./lib/SpotlightTour.provider";
 export { TourBox } from "./lib/tour-box/TourBox.component";

--- a/src/lib/AttachStep.component.tsx
+++ b/src/lib/AttachStep.component.tsx
@@ -1,7 +1,5 @@
-import React, { useContext, useEffect, useRef } from "react";
+import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { StyleProp, View, ViewStyle } from "react-native";
-import styled from "styled-components/native";
-
 import { SpotlightTourContext } from "./SpotlightTour.context";
 
 interface AttachStepProps {
@@ -10,30 +8,35 @@ interface AttachStepProps {
   style?: StyleProp<ViewStyle>;
 }
 
-const StepView = styled.View`
-  align-self: flex-start;
-`;
+export const AttachStep: React.FC<AttachStepProps> = ({ children, disabled, index, style, }) => {
 
-export const AttachStep: React.FC<AttachStepProps> = ({ children, disabled, index, style }) => {
+  const [ childStyle, setChildStyle ] = useState({});
   const { current, changeSpot, spot } = useContext(SpotlightTourContext);
 
   const childRef = useRef<View>(null);
 
+  const componentStyle = useMemo<StyleProp<ViewStyle>>(
+    () => [ childStyle, style ],
+    []
+  );
+
   useEffect(() => {
     if (!spot) {
       changeSpot({ height: 0, width: 0, x: 0, y: 0 });
+      setChildStyle({ height: 0, width: 0 });
     }
 
     if (!disabled && current === index) {
       childRef.current?.measureInWindow((x, y, width, height) => {
         changeSpot({ height, width, x, y });
+        setChildStyle({ height, width });
       });
     }
   }, [current, disabled]);
 
   return (
-    <StepView ref={childRef} collapsable={false} style={style}>
+    <View ref={childRef} collapsable={false} style={componentStyle}>
       {children}
-    </StepView>
+    </View>
   );
 };

--- a/src/lib/SpotlightTour.context.ts
+++ b/src/lib/SpotlightTour.context.ts
@@ -18,6 +18,12 @@ export enum Shape {
   RECTANGLE = "rectangle",
 }
 
+export type RectangleProps = {
+  horizontalRadius?: number;
+  verticalRadius?: number;
+  borderWidth?: number;
+};
+
 export type RenderProps = Pick<SpotlightTourCtx, "next" | "previous" | "stop"> & {
   current: number;
   isFirst: boolean;

--- a/src/lib/SpotlightTour.context.ts
+++ b/src/lib/SpotlightTour.context.ts
@@ -13,6 +13,11 @@ export enum Position {
   TOP = "top"
 }
 
+export enum Shape {
+  SPOTLIGHT = "spotlight",
+  RECTANGLE = "rectangle",
+}
+
 export type RenderProps = Pick<SpotlightTourCtx, "next" | "previous" | "stop"> & {
   current: number;
   isFirst: boolean;

--- a/src/lib/SpotlightTour.context.ts
+++ b/src/lib/SpotlightTour.context.ts
@@ -18,6 +18,11 @@ export enum Shape {
   RECTANGLE = "rectangle",
 }
 
+export enum Motion {
+  SLIDING = 'sliding',
+  FADING = 'fading',
+}
+
 export type RectangleProps = {
   horizontalRadius?: number;
   verticalRadius?: number;

--- a/src/lib/SpotlightTour.context.ts
+++ b/src/lib/SpotlightTour.context.ts
@@ -42,6 +42,7 @@ export interface TourStep {
   position: Position;
   shape?: Shape;
   shapeProperties?: RectangleProps;
+  motion?: Motion;
 }
 
 export interface SpotlightTourCtx {

--- a/src/lib/SpotlightTour.context.ts
+++ b/src/lib/SpotlightTour.context.ts
@@ -29,6 +29,7 @@ export interface TourStep {
   before?(): void | Promise<void>;
   render(props: RenderProps): React.ReactNode;
   position: Position;
+  shape?: Shape;
 }
 
 export interface SpotlightTourCtx {

--- a/src/lib/SpotlightTour.context.ts
+++ b/src/lib/SpotlightTour.context.ts
@@ -36,6 +36,7 @@ export interface TourStep {
   render(props: RenderProps): React.ReactNode;
   position: Position;
   shape?: Shape;
+  shapeProperties?: RectangleProps;
 }
 
 export interface SpotlightTourCtx {

--- a/src/lib/SpotlightTour.provider.tsx
+++ b/src/lib/SpotlightTour.provider.tsx
@@ -17,7 +17,7 @@ interface SpotlightTourProviderProps {
 }
 
 export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTourProviderProps>((props, ref) => {
-  const { children, overlayColor, overlayOpacity, steps, onStop } = props;
+  const { children, overlayColor, overlayOpacity, steps, onStop, shouldContinueOnBackdropPress } = props;
 
   const [current, setCurrent] = useState<number>();
   const [spot, setSpot] = useState<LayoutRectangle>();
@@ -103,6 +103,7 @@ export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTo
         color={overlayColor}
         opacity={overlayOpacity}
         tour={tour}
+        shouldContinueOnBackdropPress={shouldContinueOnBackdropPress}
       />
     </SpotlightTourContext.Provider>
   );

--- a/src/lib/SpotlightTour.provider.tsx
+++ b/src/lib/SpotlightTour.provider.tsx
@@ -12,6 +12,8 @@ interface SpotlightTourProviderProps {
   overlayColor?: string | number | rgbaArray;
   overlayOpacity?: number | string;
   steps: TourStep[];
+  shouldContinueOnBackdropPress?: boolean;
+  onStop?: () => void;
 }
 
 export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTourProviderProps>((props, ref) => {

--- a/src/lib/SpotlightTour.provider.tsx
+++ b/src/lib/SpotlightTour.provider.tsx
@@ -17,7 +17,7 @@ interface SpotlightTourProviderProps {
 }
 
 export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTourProviderProps>((props, ref) => {
-  const { children, overlayColor, overlayOpacity, steps } = props;
+  const { children, overlayColor, overlayOpacity, steps, onStop } = props;
 
   const [current, setCurrent] = useState<number>();
   const [spot, setSpot] = useState<LayoutRectangle>();
@@ -51,6 +51,7 @@ export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTo
 
   const stop = () => {
     setCurrent(undefined);
+    onStop?.();
   };
 
   const next = () => {

--- a/src/lib/tour-overlay/TourOverlay.component.tsx
+++ b/src/lib/tour-overlay/TourOverlay.component.tsx
@@ -57,6 +57,8 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
 
   const rectWidth = spot.width;
   const rectHeight = spot.height;
+  const rectX = spot.x;
+  const rectY = spot.y;
 
   const circleProperties = { r: radius, cx: center.x, cy: center.y };
   const rectProperties = { x: rectCoordinates.x, y: rectCoordinates.y };
@@ -66,7 +68,7 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
     [Shape.RECTANGLE]: <AnimatedRect {...rectProperties} width={rectWidth} height={rectHeight} fill="black" />,
   }[shape];
 
-  const getTipStyles = (tipLayout: LayoutRectangle): StyleProp<ViewStyle> => {
+  const getSpotlightTipStyles = (tipLayout: LayoutRectangle): StyleProp<ViewStyle> => {
     const tipMargin: string = "2%";
     const align = tourStep.alignTo ?? Align.SPOT;
 
@@ -101,8 +103,53 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
     }
   };
 
+  const getRectangleTipStyles = (tipLayout: LayoutRectangle): StyleProp<ViewStyle> => {
+    const tipMargin = 10;
+    const align = tourStep.alignTo ?? Align.SPOT;
+
+    const center = {
+      x: Math.round(rectX + rectWidth / 2),
+      y: Math.round(rectY + rectHeight / 2),
+    };
+
+    switch (tourStep.position) {
+      case Position.BOTTOM: return {
+        left: align === Align.SPOT
+          ? Math.round(center.x - tipLayout.width / 2)
+          : Math.round((vwDP(100) - tipLayout.width) / 2),
+        marginTop: tipMargin,
+        top: Math.round(rectY + rectHeight),
+      };
+
+      case Position.TOP: return {
+        left: align === Align.SPOT
+          ? Math.round(center.x - tipLayout.width / 2)
+          : Math.round((vwDP(100) - tipLayout.width) / 2),
+        marginBottom: tipMargin,
+        top: Math.round(rectY - tipLayout.height - tipMargin),
+      };
+
+      case Position.LEFT: return {
+        left: Math.round(rectX - tipLayout.width),
+        marginRight: tipMargin,
+        top: Math.round(center.y - tipLayout.height / 2),
+      };
+
+      case Position.RIGHT: return {
+        left: Math.round(rectX + rectWidth),
+        marginLeft: tipMargin,
+        top: Math.round(center.y - tipLayout.height / 2),
+      };
+    }
+  };
+
   const measureTip = (event: LayoutChangeEvent) => {
-    setTipStyle(getTipStyles(event.nativeEvent.layout));
+    const style = {
+      [Shape.SPOTLIGHT]: getSpotlightTipStyles(event.nativeEvent.layout),
+      [Shape.RECTANGLE]: getRectangleTipStyles(event.nativeEvent.layout),
+    }[shape];
+
+    setTipStyle(style);
   };
 
   useEffect(() => {

--- a/src/lib/tour-overlay/TourOverlay.component.tsx
+++ b/src/lib/tour-overlay/TourOverlay.component.tsx
@@ -5,7 +5,8 @@ import {
   LayoutRectangle,
   Modal,
   StyleProp,
-  ViewStyle
+  ViewStyle,
+  TouchableWithoutFeedback
 } from "react-native";
 import Svg, { Circle, Defs, Mask, Rect, rgbaArray } from "react-native-svg";
 
@@ -246,6 +247,7 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
       transparent={true}
       visible={true}
     >
+      <TouchableWithoutFeedback onPress={backdropPressHandler}>
       <OverlayView accessibilityLabel="Tour Overlay View">
         <Svg
           accessibilityLabel="Svg overlay view"
@@ -284,6 +286,7 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
           })}
         </TipView>
       </OverlayView>
+      </TouchableWithoutFeedback>
     </Modal>
   );
 });

--- a/src/lib/tour-overlay/TourOverlay.component.tsx
+++ b/src/lib/tour-overlay/TourOverlay.component.tsx
@@ -22,6 +22,7 @@ interface TourOverlayProps {
   color?: string | number | rgbaArray;
   opacity?: number | string;
   tour: SpotlightTourCtx;
+  shouldContinueOnBackdropPress?: boolean;
 }
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);

--- a/src/lib/tour-overlay/TourOverlay.component.tsx
+++ b/src/lib/tour-overlay/TourOverlay.component.tsx
@@ -11,7 +11,7 @@ import {
 import Svg, { Circle, Defs, Mask, Rect, rgbaArray } from "react-native-svg";
 
 import { vhDP, vwDP } from "../../helpers/responsive";
-import { Align, Position, SpotlightTourCtx } from "../SpotlightTour.context";
+import { Align, Position, SpotlightTourCtx, Shape } from "../SpotlightTour.context";
 
 import { OverlayView, TipView } from "./TourOverlay.styles";
 
@@ -26,6 +26,7 @@ interface TourOverlayProps {
 }
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
+const AnimatedRect = Animated.createAnimatedComponent(Rect);
 
 export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((props, ref) => {
   const { color = "black", opacity = 0.45, tour } = props;
@@ -40,6 +41,9 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
   const [radius] = useState(new Animated.Value(0));
   const [center] = useState(new Animated.ValueXY({ x: 0, y: 0 }));
   const [tipOpacity] = useState(new Animated.Value(0));
+  const [rectCoordinates] = useState(new Animated.ValueXY({ x: 0, y: 0 }));
+
+  const shape = tourStep.shape ?? Shape.SPOTLIGHT;
 
   const r = (Math.max(spot.width, spot.height) / 2) * 1.15;
   const cx = spot.x + (spot.width / 2);
@@ -50,6 +54,17 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
     default: false,
     ios: true
   }), [Platform.OS]);
+
+  const rectWidth = spot.width;
+  const rectHeight = spot.height;
+
+  const circleProperties = { r: radius, cx: center.x, cy: center.y };
+  const rectProperties = { x: rectCoordinates.x, y: rectCoordinates.y };
+
+  const MaskElement = {
+    [Shape.SPOTLIGHT]: <AnimatedCircle {...circleProperties} fill="black" />,
+    [Shape.RECTANGLE]: <AnimatedRect {...rectProperties} width={rectWidth} height={rectHeight} fill="black" />,
+  }[shape];
 
   const getTipStyles = (tipLayout: LayoutRectangle): StyleProp<ViewStyle> => {
     const tipMargin: string = "2%";
@@ -161,12 +176,7 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
           <Defs>
             <Mask id="mask" x={0} y={0} height="100%" width="100%">
               <Rect height="100%" width="100%" fill="#fff" />
-              <AnimatedCircle
-                r={radius}
-                cx={center.x}
-                cy={center.y}
-                fill="black"
-              />
+                {MaskElement}
             </Mask>
           </Defs>
 

--- a/src/lib/tour-overlay/TourOverlay.component.tsx
+++ b/src/lib/tour-overlay/TourOverlay.component.tsx
@@ -11,7 +11,7 @@ import {
 import Svg, { Circle, Defs, Mask, Rect, rgbaArray } from "react-native-svg";
 
 import { vhDP, vwDP } from "../../helpers/responsive";
-import { Align, Position, SpotlightTourCtx, Shape } from "../SpotlightTour.context";
+import { Align, Position, SpotlightTourCtx, Shape, Motion } from "../SpotlightTour.context";
 
 import { OverlayView, TipView } from "./TourOverlay.styles";
 
@@ -71,8 +71,17 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
   const rectX = spot.x - borderWidth;
   const rectY = spot.y - borderWidth;
 
-  const circleProperties = { r: radius, cx: center.x, cy: center.y };
-  const rectProperties = { x: rectCoordinates.x, y: rectCoordinates.y };
+  const motion = tourStep.motion ?? Motion.SLIDING;
+
+  const circleProperties = {
+    [Motion.SLIDING]: { r: radius, cx: center.x, cy: center.y },
+    [Motion.FADING]: { r, cx, cy, opacity: componentOpacity },
+  }[motion];
+
+  const rectProperties = {
+    [Motion.SLIDING]: { x: rectCoordinates.x, y: rectCoordinates.y },
+    [Motion.FADING]: { x: rectX, y: rectY, opacity: componentOpacity },
+  }[motion];
 
   const MaskElement = {
     [Shape.SPOTLIGHT]: <AnimatedCircle {...circleProperties} fill="black" />,

--- a/src/lib/tour-overlay/TourOverlay.component.tsx
+++ b/src/lib/tour-overlay/TourOverlay.component.tsx
@@ -179,6 +179,13 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
         toValue: r,
         useNativeDriver
       }),
+      Animated.spring(rectCoordinates, {
+        damping: 50,
+        mass: 5,
+        stiffness: 300,
+        toValue: { x: rectX, y: rectY },
+        useNativeDriver,
+      }),
       Animated.timing(componentOpacity, {
         delay: 500,
         duration: 500,

--- a/src/lib/tour-overlay/TourOverlay.component.tsx
+++ b/src/lib/tour-overlay/TourOverlay.component.tsx
@@ -28,6 +28,12 @@ interface TourOverlayProps {
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
 const AnimatedRect = Animated.createAnimatedComponent(Rect);
 
+const shapeProperties = {
+  borderWidth: 0,
+  horizontalRadius: 0,
+  verticalRadius: 0,
+};
+
 export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((props, ref) => {
   const { color = "black", opacity = 0.45, tour } = props;
   const { current, next, previous, spot, steps, stop } = tour;
@@ -44,6 +50,11 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
   const [rectCoordinates] = useState(new Animated.ValueXY({ x: 0, y: 0 }));
 
   const shape = tourStep.shape ?? Shape.SPOTLIGHT;
+  const {
+    borderWidth = 0,
+    horizontalRadius = 0,
+    verticalRadius = 0,
+  } = tourStep.shapeProperties ?? shapeProperties;
 
   const r = (Math.max(spot.width, spot.height) / 2) * 1.15;
   const cx = spot.x + (spot.width / 2);
@@ -55,17 +66,17 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
     ios: true
   }), [Platform.OS]);
 
-  const rectWidth = spot.width;
-  const rectHeight = spot.height;
-  const rectX = spot.x;
-  const rectY = spot.y;
+  const rectWidth = spot.width + 2 * borderWidth;
+  const rectHeight = spot.height + 2 * borderWidth;
+  const rectX = spot.x - borderWidth;
+  const rectY = spot.y - borderWidth;
 
   const circleProperties = { r: radius, cx: center.x, cy: center.y };
   const rectProperties = { x: rectCoordinates.x, y: rectCoordinates.y };
 
   const MaskElement = {
     [Shape.SPOTLIGHT]: <AnimatedCircle {...circleProperties} fill="black" />,
-    [Shape.RECTANGLE]: <AnimatedRect {...rectProperties} width={rectWidth} height={rectHeight} fill="black" />,
+    [Shape.RECTANGLE]: <AnimatedRect {...rectProperties} width={rectWidth} height={rectHeight} rx={horizontalRadius} ry={verticalRadius} fill="black" />,
   }[shape];
 
   const getSpotlightTipStyles = (tipLayout: LayoutRectangle): StyleProp<ViewStyle> => {

--- a/src/lib/tour-overlay/TourOverlay.component.tsx
+++ b/src/lib/tour-overlay/TourOverlay.component.tsx
@@ -46,8 +46,8 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
   const [tipStyle, setTipStyle] = useState<StyleProp<ViewStyle>>();
   const [radius] = useState(new Animated.Value(0));
   const [center] = useState(new Animated.ValueXY({ x: 0, y: 0 }));
-  const [tipOpacity] = useState(new Animated.Value(0));
   const [rectCoordinates] = useState(new Animated.ValueXY({ x: 0, y: 0 }));
+  const [componentOpacity] = useState(new Animated.Value(0));
 
   const shape = tourStep.shape ?? Shape.SPOTLIGHT;
   const {
@@ -179,7 +179,7 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
         toValue: r,
         useNativeDriver
       }),
-      Animated.timing(tipOpacity, {
+      Animated.timing(componentOpacity, {
         delay: 500,
         duration: 500,
         toValue: 1,
@@ -204,7 +204,7 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
   useImperativeHandle(ref, () => ({
     hideTip() {
       return new Promise<void>((resolve, reject) => {
-        Animated.timing(tipOpacity, {
+        Animated.timing(componentOpacity, {
           duration: 200,
           toValue: 0,
           useNativeDriver
@@ -250,7 +250,7 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
         <TipView
           accessibilityLabel="Tip Overlay View"
           onLayout={measureTip}
-          style={[tipStyle, { opacity: tipOpacity }]}
+          style={[tipStyle, { opacity: componentOpacity }]}
         >
           {tourStep.render({
             current,

--- a/src/lib/tour-overlay/TourOverlay.component.tsx
+++ b/src/lib/tour-overlay/TourOverlay.component.tsx
@@ -34,6 +34,8 @@ const shapeProperties = {
   verticalRadius: 0,
 };
 
+const USE_NATIVE_DRIVER = true;
+
 export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((props, ref) => {
   const { color = "black", opacity = 0.45, tour } = props;
   const { current, next, previous, spot, steps, stop } = tour;
@@ -59,12 +61,6 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
   const r = (Math.max(spot.width, spot.height) / 2) * 1.15;
   const cx = spot.x + (spot.width / 2);
   const cy = spot.y + (spot.height / 2);
-
-  const useNativeDriver = useMemo(() => Platform.select({
-    android: false,
-    default: false,
-    ios: true
-  }), [Platform.OS]);
 
   const rectWidth = spot.width + 2 * borderWidth;
   const rectHeight = spot.height + 2 * borderWidth;
@@ -179,27 +175,27 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
         mass: 5,
         stiffness: 300,
         toValue: { x: cx, y: cy },
-        useNativeDriver
+        useNativeDriver: USE_NATIVE_DRIVER
       }),
       Animated.spring(radius, {
         damping: 30,
         mass: 5,
         stiffness: 300,
         toValue: r,
-        useNativeDriver
+        useNativeDriver: USE_NATIVE_DRIVER
       }),
       Animated.spring(rectCoordinates, {
         damping: 50,
         mass: 5,
         stiffness: 300,
         toValue: { x: rectX, y: rectY },
-        useNativeDriver,
+        useNativeDriver: USE_NATIVE_DRIVER
       }),
       Animated.timing(componentOpacity, {
         delay: 500,
         duration: 500,
         toValue: 1,
-        useNativeDriver
+        useNativeDriver: USE_NATIVE_DRIVER
       })
     ]);
 
@@ -223,7 +219,7 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
         Animated.timing(componentOpacity, {
           duration: 200,
           toValue: 0,
-          useNativeDriver
+          useNativeDriver: USE_NATIVE_DRIVER
         })
         .start(({ finished }) => finished
           ? resolve()

--- a/src/lib/tour-overlay/TourOverlay.component.tsx
+++ b/src/lib/tour-overlay/TourOverlay.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useImperativeHandle, useState } from "react";
+import React, { useEffect, useImperativeHandle, useState, useCallback } from "react";
 import {
   Animated,
   LayoutChangeEvent,
@@ -37,7 +37,7 @@ const shapeProperties = {
 const USE_NATIVE_DRIVER = true;
 
 export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((props, ref) => {
-  const { color = "black", opacity = 0.45, tour } = props;
+  const { color = "black", opacity = 0.45, tour, shouldContinueOnBackdropPress } = props;
   const { current, next, previous, spot, steps, stop } = tour;
 
   const isLastStep = current === steps.length - 1;
@@ -85,6 +85,14 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
     [Shape.SPOTLIGHT]: <AnimatedCircle {...circleProperties} fill="black" />,
     [Shape.RECTANGLE]: <AnimatedRect {...rectProperties} width={rectWidth} height={rectHeight} rx={horizontalRadius} ry={verticalRadius} fill="black" />,
   }[shape];
+
+  const backdropPressHandler = useCallback(() => {
+    if (!shouldContinueOnBackdropPress) {
+      return;
+    }
+
+    return isLastStep ? stop() : next();
+  }, [isLastStep, shouldContinueOnBackdropPress, stop, next]);
 
   const getSpotlightTipStyles = (tipLayout: LayoutRectangle): StyleProp<ViewStyle> => {
     const tipMargin: string = "2%";

--- a/src/lib/tour-overlay/TourOverlay.component.tsx
+++ b/src/lib/tour-overlay/TourOverlay.component.tsx
@@ -38,7 +38,7 @@ const shapeProperties = {
 const USE_NATIVE_DRIVER = true;
 
 export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((props, ref) => {
-  const { color = "black", opacity = 0.45, tour, shouldContinueOnBackdropPress } = props;
+  const { color = "black", opacity = 0.45, tour, shouldContinueOnBackdropPress = false } = props;
   const { current, next, previous, spot, steps, stop } = tour;
 
   const isLastStep = current === steps.length - 1;

--- a/src/lib/tour-overlay/TourOverlay.component.tsx
+++ b/src/lib/tour-overlay/TourOverlay.component.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useImperativeHandle, useMemo, useState } from "react";
+import React, { useEffect, useImperativeHandle, useState } from "react";
 import {
   Animated,
   LayoutChangeEvent,
   LayoutRectangle,
   Modal,
-  Platform,
   StyleProp,
   ViewStyle
 } from "react-native";
@@ -39,6 +38,8 @@ const USE_NATIVE_DRIVER = true;
 export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((props, ref) => {
   const { color = "black", opacity = 0.45, tour } = props;
   const { current, next, previous, spot, steps, stop } = tour;
+
+  const isLastStep = current === steps.length - 1;
 
   if (!spot || current === undefined) {
     return null;
@@ -267,7 +268,7 @@ export const TourOverlay = React.forwardRef<TourOverlayRef, TourOverlayProps>((p
           {tourStep.render({
             current,
             isFirst: current === 0,
-            isLast: current === steps.length - 1,
+            isLast: isLastStep,
             next,
             previous,
             stop


### PR DESCRIPTION
### Premise

The library is good in general. During the tests, our team didn't encounter any issues. It works great and looks clean from the code perspective as well. Great work!

Unfortunately, it doesn't cover all requirements of our project at the moment. That's why we decided to improve this library by adding alternatives for the highlighted area and animation, a touchable backdrop, Native Driver for Android, etc.

### Status

Stable. A review will be appreciated.

### Changes

- Code refactored (removed unused imports, refactored AttachStep component)
- Added the possibility to use a **rectangular** spotlight as an alternative to a circle using the **shape** prop
- Added a possibility to style a rectangular spotlight with **border-width** and **border-radius** props using the **shapeProperties** prop
- Added the possibility to use a **fade** animation as an alternative to sliding using the **motion** prop
- Enabled **Native Driver** for animations by default (was previously disabled for Android)
- Added the possibility to prepare actions for the **stop** event using the **onStop** prop
- Added the possibility to go to the **next** step by pressing on the backdrop using the **shouldContinueOnBackdropPress** prop
