### PR TITLE
docs: added missing type in AttachStep docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ following properties:
 | ---------- | :-------: | -------- | ----------- |
 | `index`    | Yes       | N/A      | Defines the order for the tour sequence (`Number`). |
 | `disabled` | No        | `false`  | Defines if the library should highlight the component or not (`Boolean`). |
+| `style`    | No        | N/A      | Defines the style for the `AttachStep` that wraps the highlighted components (`ViewStyle`). |
 
 
 ### Setting Tour Steps


### PR DESCRIPTION
When I needed to add some styling to `AttachStep` I couldn't find anything in the documentation so I had to take a look at the source code and found out it already had a style prop! This could be helpful to anyone who might not know `style` prop is available