### PR TITLE
fix(core): AttachStep issues

### DIFF
--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1418,7 +1418,7 @@ __metadata:
     react: ">=16.8.0"
     react-native: ">=0.50.0"
     react-native-svg: ">=12.1.0"
-  checksum: 19be6c375273a9ad3b54476165f48b911065406436a2cf0c629967b1889866db200fe216cf223189c14552c9000d461e545c5501fb2a0f865162bd6453c4822d
+  checksum: a521283956f54208848df43f8a7113bbc19176cd02b92448eb3ddddef671ab63f5f867d2453c2b0fae9710623bb78cc8fb7f479b260e7f05bd95e38231d12972
   languageName: node
   linkType: hard
 

--- a/src/lib/AttachStep.component.tsx
+++ b/src/lib/AttachStep.component.tsx
@@ -1,40 +1,47 @@
-import React, { ReactElement, ReactNode, useContext, useEffect, useRef } from "react";
-import { StyleProp, View, ViewStyle } from "react-native";
-import styled from "styled-components/native";
+
+import React, { ReactElement, useCallback, useContext, useLayoutEffect, useRef } from "react";
+import { LayoutChangeEvent, View } from "react-native";
 
 import { SpotlightTourContext } from "./SpotlightTour.context";
 
 interface AttachStepProps {
-  children: ReactNode;
+  children: ReactElement;
   disabled?: boolean;
   index: number;
-  style?: StyleProp<ViewStyle>;
 }
 
-const StepView = styled.View`
-  align-self: flex-start;
-`;
-
-export function AttachStep({ children, disabled, index, style }: AttachStepProps): ReactElement {
+export function AttachStep({ children, disabled, index }: AttachStepProps): ReactElement {
   const { current, changeSpot, spot } = useContext(SpotlightTourContext);
 
   const childRef = useRef<View>(null);
 
-  useEffect(() => {
+  const adjustSpotToView = useCallback((): void => {
+    childRef.current?.measureInWindow((x, y, width, height) => {
+      changeSpot({ height, width, x, y });
+    });
+  }, [childRef]);
+
+  useLayoutEffect(() => {
     if (!spot) {
       changeSpot({ height: 0, width: 0, x: 0, y: 0 });
     }
 
     if (!disabled && current === index) {
-      childRef.current?.measureInWindow((x, y, width, height) => {
-        changeSpot({ height, width, x, y });
-      });
+      adjustSpotToView();
     }
   }, [current, disabled]);
 
-  return (
-    <StepView ref={childRef} collapsable={false} style={style}>
-      {children}
-    </StepView>
+  const onLayout = (event: LayoutChangeEvent): void => {
+    if (spot && !disabled && current === index) {
+      adjustSpotToView();
+    }
+
+    children.props?.onLayout?.(event);
+  };
+
+  return React.cloneElement(
+    children,
+    { ...children.props, onLayout, ref: childRef },
+    children.props?.children
   );
 }

--- a/src/lib/SpotlightTour.context.ts
+++ b/src/lib/SpotlightTour.context.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react";
+import { createContext, ReactElement, useContext } from "react";
 import { LayoutRectangle, Omit } from "react-native";
 
 export enum Align {
@@ -21,21 +21,21 @@ export type RenderProps = Pick<SpotlightTourCtx, "next" | "previous" | "stop"> &
 
 export interface TourStep {
   alignTo?: Align;
-  before?(): void | Promise<void>;
-  render(props: RenderProps): React.ReactNode;
+  before?: () => void | Promise<void>;
+  render: (props: RenderProps) => ReactElement;
   position: Position;
 }
 
 export interface SpotlightTourCtx {
-  changeSpot(spot: LayoutRectangle): void;
+  changeSpot: (spot: LayoutRectangle) => void;
   current?: number;
-  goTo(index: number): void;
-  next(): void;
-  previous(): void;
+  goTo: (index: number) => void;
+  next: () => void;
+  previous: () => void;
   spot?: LayoutRectangle;
-  start(): void;
+  start: () => void;
   steps: TourStep[];
-  stop(): void;
+  stop: () => void;
 }
 
 export const SpotlightTourContext = createContext<SpotlightTourCtx>({

--- a/src/lib/SpotlightTour.provider.tsx
+++ b/src/lib/SpotlightTour.provider.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useImperativeHandle, useRef, useState } from "react";
+import React, { useCallback, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { ColorValue, LayoutRectangle } from "react-native";
 
 import { ChildFn, isChildFunction, isPromise } from "../helpers/common";
@@ -36,35 +36,41 @@ export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTo
     }
 
     return Promise.resolve();
-  }, [steps]);
+  }, [steps, overlayRef.current]);
 
-  const changeSpot = (newSpot: LayoutRectangle) => {
+  const changeSpot = useCallback((newSpot: LayoutRectangle): void => {
     setSpot(newSpot);
-  };
+  }, []);
 
-  const start = () => {
+  const start = useCallback((): void => {
     renderStep(0);
-  };
+  }, [renderStep]);
 
-  const stop = () => {
+  const stop = useCallback((): void => {
     setCurrent(undefined);
-  };
+  }, []);
 
-  const next = () => {
+  const next = useCallback((): void => {
     if (current !== undefined && current < steps.length - 1) {
       renderStep(current + 1);
     }
-  };
+  }, [renderStep, current, steps.length]);
 
-  const previous = () => {
+  const previous = useCallback((): void => {
     if (current !== undefined && current > 0) {
       renderStep(current - 1);
     }
-  };
+  }, [renderStep, current]);
 
-  const goTo = (index: number) => {
+  const goTo = useCallback((index: number): void => {
     renderStep(index);
-  };
+  }, [renderStep]);
+
+  const currentStep = useMemo((): TourStep | undefined => {
+    return current !== undefined
+      ? steps[current]
+      : undefined;
+  }, [steps, current]);
 
   const tour: SpotlightTourCtx = {
     changeSpot,
@@ -94,12 +100,16 @@ export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTo
         : <>{children}</>
       }
 
-      <TourOverlay
-        ref={overlayRef}
-        color={overlayColor}
-        opacity={overlayOpacity}
-        tour={tour}
-      />
+      {spot !== undefined && current !== undefined && currentStep !== undefined && (
+        <TourOverlay
+          ref={overlayRef}
+          color={overlayColor}
+          current={current}
+          opacity={overlayOpacity}
+          spot={spot}
+          tourStep={currentStep}
+        />
+      )}
     </SpotlightTourContext.Provider>
   );
 });

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -177,7 +177,7 @@ describe("Spotlight tour", () => {
           left: 325,
           marginBottom: "2%",
           position: "absolute",
-          top: -79
+          top: -72
         });
       });
     });


### PR DESCRIPTION
This PR fixes a few issues present in the `AttachStep` component. The most relevant of them is that the component was using a `View` to wrap its children (the attached step component), which allowed (or prevented) styling this view, causing issues with the resulting measures for the spotlight width and height.

The `AttachStep` component should not be considered something that renders on the screen. Instead, this is a transient component used to mark something as one of the steps of the tour. Users should do styling on the children of `AttachStep` to achieve the desired behavior.