### PR TITLE
perf(core): Refactor animation flow

### DIFF
--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  transformer: {
+    getTransformOptions: () => ({
+      transform: {
+        experimentalImportSupport: false,
+        inlineRequires: true
+      }
+    })
+  }
+};

--- a/example/metro.config.ts
+++ b/example/metro.config.ts
@@ -1,8 +1,0 @@
-export const transformer = {
-  getTransformOptions: async () => ({
-    transform: {
-      experimentalImportSupport: false,
-      inlineRequires: true
-    }
-  })
-};

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -122,6 +122,7 @@ export const App: React.FC = () => {
         steps={tourSteps}
         overlayColor={"gray"}
         overlayOpacity={0.36}
+        nativeDriver={true}
       >
         {({ start }) => (
           <>

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1418,7 +1418,7 @@ __metadata:
     react: ">=16.8.0"
     react-native: ">=0.50.0"
     react-native-svg: ">=12.1.0"
-  checksum: a521283956f54208848df43f8a7113bbc19176cd02b92448eb3ddddef671ab63f5f867d2453c2b0fae9710623bb78cc8fb7f479b260e7f05bd95e38231d12972
+  checksum: 465d31a9bfb775dc4f3aa89e6a2702715a19f345ac7f3cac5b00ceb942b5912676e158d59d7fe6fb2905b303a04159ceb370721745fc1dd6e80ac70947403fe2
   languageName: node
   linkType: hard
 

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1418,7 +1418,7 @@ __metadata:
     react: ">=16.8.0"
     react-native: ">=0.50.0"
     react-native-svg: ">=12.1.0"
-  checksum: 465d31a9bfb775dc4f3aa89e6a2702715a19f345ac7f3cac5b00ceb942b5912676e158d59d7fe6fb2905b303a04159ceb370721745fc1dd6e80ac70947403fe2
+  checksum: e7a3abe847c65559e2eab01be0b781b7ae7268564e8221b4cac41dc6ebbcf576a1fd7d8a78b4843fe97af186467c59c7b5c3764f8204077d84304ff472d8d9e7
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.prod.json",
     "compile": "tsc -p tsconfig.json",
-    "dev": "./scripts/install-dev-on-example.sh",
+    "dev": "./scripts/install-dev-on-example.sh && cd example && yarn start",
     "lint": "tslint -c tslint.json \"!(build|dist)/**/*.ts?(x)\"",
     "semantic-release": "semantic-release",
     "test": "jest"

--- a/src/lib/AttachStep.component.tsx
+++ b/src/lib/AttachStep.component.tsx
@@ -1,6 +1,6 @@
 
-import React, { ReactElement, useCallback, useContext, useLayoutEffect, useRef } from "react";
-import { LayoutChangeEvent, View } from "react-native";
+import React, { ReactElement, useContext, useLayoutEffect, useRef } from "react";
+import { View } from "react-native";
 
 import { SpotlightTourContext } from "./SpotlightTour.context";
 
@@ -11,37 +11,21 @@ interface AttachStepProps {
 }
 
 export function AttachStep({ children, disabled, index }: AttachStepProps): ReactElement {
-  const { current, changeSpot, spot } = useContext(SpotlightTourContext);
+  const { current, changeSpot } = useContext(SpotlightTourContext);
 
   const childRef = useRef<View>(null);
 
-  const adjustSpotToView = useCallback((): void => {
-    childRef.current?.measureInWindow((x, y, width, height) => {
-      changeSpot({ height, width, x, y });
-    });
-  }, [childRef]);
-
   useLayoutEffect(() => {
-    if (!spot) {
-      changeSpot({ height: 0, width: 0, x: 0, y: 0 });
-    }
-
     if (!disabled && current === index) {
-      adjustSpotToView();
+      childRef.current?.measureInWindow((x, y, width, height) => {
+        changeSpot({ height, width, x, y });
+      });
     }
-  }, [current, disabled]);
-
-  const onLayout = (event: LayoutChangeEvent): void => {
-    if (spot && !disabled && current === index) {
-      adjustSpotToView();
-    }
-
-    children.props?.onLayout?.(event);
-  };
+  }, [current]);
 
   return React.cloneElement(
     children,
-    { ...children.props, onLayout, ref: childRef },
+    { ...children.props, ref: childRef },
     children.props?.children
   );
 }

--- a/src/lib/SpotlightTour.context.ts
+++ b/src/lib/SpotlightTour.context.ts
@@ -32,7 +32,7 @@ export interface SpotlightTourCtx {
   goTo: (index: number) => void;
   next: () => void;
   previous: () => void;
-  spot?: LayoutRectangle;
+  spot: LayoutRectangle;
   start: () => void;
   steps: TourStep[];
   stop: () => void;
@@ -43,6 +43,7 @@ export const SpotlightTourContext = createContext<SpotlightTourCtx>({
   goTo: () => undefined,
   next: () => undefined,
   previous: () => undefined,
+  spot: { height: 0, width: 0, x: 0, y: 0 },
   start: () => undefined,
   steps: [],
   stop: () => undefined

--- a/src/lib/SpotlightTour.context.ts
+++ b/src/lib/SpotlightTour.context.ts
@@ -38,18 +38,25 @@ export interface SpotlightTourCtx {
   stop: () => void;
 }
 
+export type SpotlightTour = Omit<SpotlightTourCtx, "changeSpot" | "spot" | "steps">;
+
+export const ZERO_SPOT: LayoutRectangle = {
+  height: 0,
+  width: 0,
+  x: 0,
+  y: 0
+};
+
 export const SpotlightTourContext = createContext<SpotlightTourCtx>({
   changeSpot: () => undefined,
   goTo: () => undefined,
   next: () => undefined,
   previous: () => undefined,
-  spot: { height: 0, width: 0, x: 0, y: 0 },
+  spot: ZERO_SPOT,
   start: () => undefined,
   steps: [],
   stop: () => undefined
 });
-
-export type SpotlightTour = Omit<SpotlightTourCtx, "changeSpot" | "spot" | "steps">;
 
 export function useSpotlightTour(): SpotlightTour {
   const { current, goTo, next, previous, start, stop } = useContext(SpotlightTourContext);

--- a/src/lib/SpotlightTour.provider.tsx
+++ b/src/lib/SpotlightTour.provider.tsx
@@ -3,40 +3,88 @@ import { ColorValue, LayoutRectangle } from "react-native";
 
 import { ChildFn, isChildFunction, isPromise } from "../helpers/common";
 
-import { SpotlightTour, SpotlightTourContext, SpotlightTourCtx, TourStep } from "./SpotlightTour.context";
+import { Position, SpotlightTour, SpotlightTourContext, SpotlightTourCtx, TourStep } from "./SpotlightTour.context";
 import { TourOverlay, TourOverlayRef } from "./tour-overlay/TourOverlay.component";
 
-interface SpotlightTourProviderProps {
-  children: React.ReactNode | ChildFn<SpotlightTour>;
-  overlayColor?: ColorValue;
-  overlayOpacity?: number | string;
-  steps: TourStep[];
+export interface OSConfig<T> {
+  android: T;
+  ios: T;
 }
 
+interface SpotlightTourProviderProps {
+  /**
+   * The children to render in the provider. It accepts either a React
+   * component, or a function that returns a React component. When the child is
+   * a funtion, the `SpotlightTour` context can be accessed from the first
+   * argument.
+   */
+  children: React.ReactNode | ChildFn<SpotlightTour>;
+  /**
+   * The color of the overlay of the tour.
+   *
+   * @default black
+   */
+  overlayColor?: ColorValue;
+  /**
+   * The opacity applied to the overlay of the tour (between 0 to 1).
+   *
+   * @default 0.45
+   */
+  overlayOpacity?: number;
+  /**
+   * An array of `TourStep` objects that define each step of the tour.
+   */
+  steps: TourStep[];
+  /**
+   * Define if the animations in the tour should use the native driver or not.
+   * A boolean can be used to apply the same value to both Android and iOS, or
+   * an object with `android` and `ios` keys can be used to define a value for
+   * each OS.
+   *
+   * @default false
+   */
+  nativeDriver?: boolean | OSConfig<boolean>;
+}
+
+const ZERO_SPOT: LayoutRectangle = {
+  height: 0,
+  width: 0,
+  x: 0,
+  y: 0
+};
+
 export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTourProviderProps>((props, ref) => {
-  const { children, overlayColor, overlayOpacity, steps } = props;
+  const {
+    children,
+    overlayColor = "black",
+    overlayOpacity = 0.45,
+    steps,
+    nativeDriver = false
+  } = props;
 
   const [current, setCurrent] = useState<number>();
-  const [spot, setSpot] = useState<LayoutRectangle>();
+  const [spot, setSpot] = useState(ZERO_SPOT);
 
-  const overlayRef = useRef<TourOverlayRef>(null);
+  const overlay = useRef<TourOverlayRef>({
+    hideTooltip: () => Promise.resolve({ finished: false })
+  });
 
   const renderStep = useCallback((index: number) => {
     if (steps[index] !== undefined) {
-      const beforeHook = steps[index]?.before?.();
-      const beforePromise = isPromise(beforeHook)
-        ? beforeHook
+      const beforeResult = steps[index]?.before?.();
+      const beforePromise = isPromise(beforeResult)
+        ? beforeResult
         : Promise.resolve();
 
       return Promise.all([
         beforePromise,
-        overlayRef.current?.hideTip()
+        overlay.current.hideTooltip()
       ])
       .then(() => setCurrent(index));
     }
 
     return Promise.resolve();
-  }, [steps, overlayRef.current]);
+  }, [steps]);
 
   const changeSpot = useCallback((newSpot: LayoutRectangle): void => {
     setSpot(newSpot);
@@ -48,6 +96,7 @@ export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTo
 
   const stop = useCallback((): void => {
     setCurrent(undefined);
+    setSpot(ZERO_SPOT);
   }, []);
 
   const next = useCallback((): void => {
@@ -66,10 +115,12 @@ export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTo
     renderStep(index);
   }, [renderStep]);
 
-  const currentStep = useMemo((): TourStep | undefined => {
-    return current !== undefined
+  const currentStep = useMemo((): TourStep => {
+    const step = current !== undefined
       ? steps[current]
       : undefined;
+
+    return step ?? { position: Position.BOTTOM, render: () => <></> };
   }, [steps, current]);
 
   const tour: SpotlightTourCtx = {
@@ -100,16 +151,15 @@ export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTo
         : <>{children}</>
       }
 
-      {spot !== undefined && current !== undefined && currentStep !== undefined && (
-        <TourOverlay
-          ref={overlayRef}
-          color={overlayColor}
-          current={current}
-          opacity={overlayOpacity}
-          spot={spot}
-          tourStep={currentStep}
-        />
-      )}
+      <TourOverlay
+        ref={overlay}
+        color={overlayColor}
+        current={current}
+        opacity={overlayOpacity}
+        spot={spot}
+        tourStep={currentStep}
+        nativeDriver={nativeDriver}
+      />
     </SpotlightTourContext.Provider>
   );
 });

--- a/src/lib/SpotlightTour.provider.tsx
+++ b/src/lib/SpotlightTour.provider.tsx
@@ -3,7 +3,7 @@ import { ColorValue, LayoutRectangle } from "react-native";
 
 import { ChildFn, isChildFunction, isPromise } from "../helpers/common";
 
-import { Position, SpotlightTour, SpotlightTourContext, SpotlightTourCtx, TourStep } from "./SpotlightTour.context";
+import { Position, SpotlightTour, SpotlightTourContext, SpotlightTourCtx, TourStep, ZERO_SPOT } from "./SpotlightTour.context";
 import { TourOverlay, TourOverlayRef } from "./tour-overlay/TourOverlay.component";
 
 export interface OSConfig<T> {
@@ -46,20 +46,13 @@ interface SpotlightTourProviderProps {
   nativeDriver?: boolean | OSConfig<boolean>;
 }
 
-const ZERO_SPOT: LayoutRectangle = {
-  height: 0,
-  width: 0,
-  x: 0,
-  y: 0
-};
-
 export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTourProviderProps>((props, ref) => {
   const {
     children,
     overlayColor = "black",
     overlayOpacity = 0.45,
     steps,
-    nativeDriver = false
+    nativeDriver = true
   } = props;
 
   const [current, setCurrent] = useState<number>();
@@ -69,21 +62,19 @@ export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTo
     hideTooltip: () => Promise.resolve({ finished: false })
   });
 
-  const renderStep = useCallback((index: number) => {
+  const renderStep = useCallback((index: number): void => {
     if (steps[index] !== undefined) {
       const beforeResult = steps[index]?.before?.();
       const beforePromise = isPromise(beforeResult)
         ? beforeResult
         : Promise.resolve();
 
-      return Promise.all([
+      Promise.all([
         beforePromise,
         overlay.current.hideTooltip()
       ])
       .then(() => setCurrent(index));
     }
-
-    return Promise.resolve();
   }, [steps]);
 
   const changeSpot = useCallback((newSpot: LayoutRectangle): void => {

--- a/src/lib/tour-overlay/TourOverlay.styles.ts
+++ b/src/lib/tour-overlay/TourOverlay.styles.ts
@@ -1,4 +1,3 @@
-import { Animated, ViewProps } from "react-native";
 import styled from "styled-components/native";
 
 import { vh, vw } from "../../helpers/responsive";
@@ -6,8 +5,4 @@ import { vh, vw } from "../../helpers/responsive";
 export const OverlayView = styled.View`
   height: ${vh(100)};
   width: ${vw(100)};
-`;
-
-export const TipView = styled(Animated.View)<ViewProps>`
-  position: absolute;
 `;

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -11,22 +11,22 @@ import { BASE_STEP, TestScreen } from "./helpers/TestTour";
 describe("Spotlight tour", () => {
   describe("when the tour is not running", () => {
     it("the overlay is not shown", async () => {
-      const { getByText, queryByLabelText } = render(<TestScreen />);
+      const { getByText, queryByTestId } = render(<TestScreen />);
 
       await waitFor(() => getByText("Start"));
 
-      expect(queryByLabelText("Tour Overlay View")).toBeNull();
+      expect(queryByTestId("Overlay View")).toBeNull();
     });
 
     describe("and the start button is pressed", () => {
       it("shows the overlay view", async () => {
-        const { getByText, getByLabelText } = render(<TestScreen />);
+        const { getByText, getByTestId } = render(<TestScreen />);
 
         await waitFor(() => getByText("Start"));
 
         fireEvent.press(getByText("Start"));
 
-        await waitFor(() => getByLabelText("Tour Overlay View"));
+        await waitFor(() => getByTestId("Overlay View"));
       });
     });
   });
@@ -34,15 +34,15 @@ describe("Spotlight tour", () => {
   describe("when the tour is running", () => {
     describe("and the tour moves to the first spot", () => {
       it("wraps the component with the SVG circle", async () => {
-        const { getByText, getByLabelText } = render(<TestScreen />);
+        const { getByText, getByTestId } = render(<TestScreen />);
 
         await waitFor(() => getByText("Start"));
 
         fireEvent.press(getByText("Start"));
 
-        await waitFor(() => getByLabelText("Tip Overlay View"));
+        await waitFor(() => getByTestId("Tooltip View"));
 
-        fireEvent(getByLabelText("Tip Overlay View"), "onLayout", {
+        fireEvent(getByTestId("Tooltip View"), "onLayout", {
           nativeEvent: {
             layout: {
               height: viewMockMeasureData.height,
@@ -51,10 +51,10 @@ describe("Spotlight tour", () => {
           }
         });
 
-        await waitFor(() => getByLabelText("Svg overlay view"));
+        await waitFor(() => getByTestId("Spot Svg"));
 
         const svgCircleProps = findPropsOnTestInstance(
-          getByLabelText("Svg overlay view"),
+          getByTestId("Spot Svg"),
           "RNSVGCircle"
         );
 
@@ -73,7 +73,7 @@ describe("Spotlight tour", () => {
       });
 
       it("adds the tip view on the right position", async () => {
-        const { getByText, getByLabelText } = render(<TestScreen />);
+        const { getByText, getByTestId } = render(<TestScreen />);
 
         await waitFor(() => getByText("Start"));
 
@@ -81,9 +81,9 @@ describe("Spotlight tour", () => {
 
         await waitFor(() => getByText("Step 1"));
 
-        await waitFor(() => getByLabelText("Tip Overlay View"));
+        await waitFor(() => getByTestId("Tooltip View"));
 
-        fireEvent(getByLabelText("Tip Overlay View"), "onLayout", {
+        fireEvent(getByTestId("Tooltip View"), "onLayout", {
           nativeEvent: {
             layout: {
               height: viewMockMeasureData.height,
@@ -92,9 +92,9 @@ describe("Spotlight tour", () => {
           }
         });
 
-        await waitFor(() => getByLabelText("Svg overlay view"));
+        await waitFor(() => getByTestId("Spot Svg"));
 
-        expect(getByLabelText("Tip Overlay View")).toHaveStyle({
+        expect(getByTestId("Tooltip View")).toHaveStyle({
           left: 275,
           marginTop: "2%",
           position: "absolute",
@@ -105,7 +105,7 @@ describe("Spotlight tour", () => {
 
     describe("and the tour moves to the second spot", () => {
       it("wraps the component with the SVG circle", async () => {
-        const { getByText, getByLabelText } = render(<TestScreen />);
+        const { getByText, getByTestId } = render(<TestScreen />);
 
         await waitFor(() => getByText("Start"));
 
@@ -117,7 +117,7 @@ describe("Spotlight tour", () => {
 
         await waitFor(() => getByText("Step 2"));
 
-        fireEvent(getByLabelText("Tip Overlay View"), "onLayout", {
+        fireEvent(getByTestId("Tooltip View"), "onLayout", {
           nativeEvent: {
             layout: {
               height: buttonMockMeasureData.height,
@@ -126,10 +126,10 @@ describe("Spotlight tour", () => {
           }
         });
 
-        await waitFor(() => getByLabelText("Svg overlay view"));
+        await waitFor(() => getByTestId("Spot Svg"));
 
         const svgCircleProps = findPropsOnTestInstance(
-          getByLabelText("Svg overlay view"),
+          getByTestId("Spot Svg"),
           "RNSVGCircle"
         );
 
@@ -148,7 +148,7 @@ describe("Spotlight tour", () => {
       });
 
       it("adds the second tip view on the right position", async () => {
-        const { getByText, getByLabelText } = render(<TestScreen />);
+        const { getByText, getByTestId } = render(<TestScreen />);
 
         await waitFor(() => getByText("Start"));
 
@@ -160,9 +160,9 @@ describe("Spotlight tour", () => {
 
         await waitFor(() => getByText("Step 2"));
 
-        await waitFor(() => getByLabelText("Tip Overlay View"));
+        await waitFor(() => getByTestId("Tooltip View"));
 
-        fireEvent(getByLabelText("Tip Overlay View"), "onLayout", {
+        fireEvent(getByTestId("Tooltip View"), "onLayout", {
           nativeEvent: {
             layout: {
               height: buttonMockMeasureData.height,
@@ -171,9 +171,9 @@ describe("Spotlight tour", () => {
           }
         });
 
-        await waitFor(() => getByLabelText("Svg overlay view"));
+        await waitFor(() => getByTestId("Spot Svg"));
 
-        expect(getByLabelText("Tip Overlay View")).toHaveStyle({
+        expect(getByTestId("Tooltip View")).toHaveStyle({
           left: 325,
           marginBottom: "2%",
           position: "absolute",
@@ -185,7 +185,7 @@ describe("Spotlight tour", () => {
 
   describe("and the tour is stopped", () => {
     it("unmounts the overlay view", async () => {
-      const { getByText, queryByLabelText } = render(<TestScreen />);
+      const { getByText, queryByTestId } = render(<TestScreen />);
 
       await waitFor(() => getByText("Start"));
 
@@ -195,7 +195,7 @@ describe("Spotlight tour", () => {
 
       fireEvent.press(getByText("Stop"));
 
-      expect(queryByLabelText("Tour Overlay View")).toBeNull();
+      expect(queryByTestId("Overlay View")).toBeNull();
     });
   });
 


### PR DESCRIPTION
This PR refactors the animation flow of the tour to fix the issues when running the animations on the native threads on both iOS and Android. In a nutshell, the problem was that the first animation was trying to start before both the Overlay and the SVG components were rendered. This caused a problem when `useNativeDriver: true` was set on the animation, causing the first spotlight to not appear on iOS, and the tour to crash on Android.

Additionally, a new prop was added to the `<SpotlightTourProvider />` component so users can choose to enable/disable animation on the native thread based on the OS. Some other changes on this PR includes:
- Fix the example `metro.config.js` file, as the .ts file was not being recognized
- Improve `yarn dev` command to start the example bundler at the end
- Add JSDocs to the `SpotlightTourProviderProps` (we need to add more documentation to the public API)
- refactored tests to use `testID` instead of accessibility labels. As a library, we don't want the internal accessibility labels to interfere with users' applications and/or tests.