### PR TITLE
chore(ci): Refactor release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 
 on:
   push:
+    branches-ignore: [release]
   workflow_call:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 
 on:
   push:
-    branches-ignore: [chore/refactor-release-workflow]
   workflow_call:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 ---
 name: CI
 
-on: push
+on:
+  push:
+  workflow_call:
 
 concurrency:
   group: ci-${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 
 on:
   push:
+    branches-ignore: [chore/refactor-release-workflow]
   workflow_call:
 
 concurrency:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,10 +2,7 @@
 name: Pages
 
 on:
-  workflow_run:
-    workflows: [Release]
-    branches: [release]
-    types: [completed]
+  workflow_call:
 
 permissions:
   contents: read
@@ -18,14 +15,11 @@ concurrency:
 
 jobs:
   build:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: release
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Build with Jekyll

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  pages:
+    uses: .github/workflows/pages.yml
+    needs: [deploy]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,7 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
+  push:
     branches: [release]
 
 concurrency:
@@ -12,13 +10,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    uses: ./.github/workflows/ci.yml
+
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    needs: [build]
+
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: release
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,5 +31,5 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   pages:
-    uses: .github/workflows/pages.yml
+    uses: ./.github/workflows/pages.yml
     needs: [deploy]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 
 on:
   push:
-    branches: [release]
+    branches: [chore/refactor-release-workflow]
 
 concurrency:
   group: release
@@ -25,7 +25,7 @@ jobs:
           cache: yarn
       - run: yarn install --immutable
       - run: yarn build
-      - run: yarn semantic-release
+      - run: yarn semantic-release --dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 
 on:
   push:
-    branches: [chore/refactor-release-workflow]
+    branches: [release]
 
 concurrency:
   group: release
@@ -25,7 +25,7 @@ jobs:
           cache: yarn
       - run: yarn install --immutable
       - run: yarn build
-      - run: yarn semantic-release --dry-run
+      - run: yarn semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,5 @@
+{
+  "branches": [
+    "release"
+  ]
+}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
   "branches": [
-    "chore/refactor-release-workflow"
+    "release"
   ]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
   "branches": [
-    "release"
+    "chore/refactor-release-workflow"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,22 @@
   "version": "0.0.0",
   "description": "React Native library to implement a highly customizable app tour feature with an awesome spotlight effect",
   "repository": "git@github.com:stackbuilders/react-native-spotlight-tour.git",
-  "author": "Stack Builders <info@stackbuilders.com>",
+  "homepage": "https://stackbuilders.github.io/react-native-spotlight-tour/",
+  "bugs": "https://github.com/stackbuilders/react-native-spotlight-tour/issues",
+  "author": "Stack Builders <info@stackbuilders.com> (https://github.com/stackbuilders)",
   "license": "MIT",
+  "keywords": [
+    "app-tour",
+    "android",
+    "customizable",
+    "ios",
+    "react-native",
+    "step-by-step",
+    "spotlight",
+    "spotlight-tour",
+    "tour",
+    "user-guide"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "react-native": "./src/index.ts",
@@ -55,13 +69,16 @@
     "react-native": ">=0.50.0",
     "react-native-svg": ">=12.1.0"
   },
-  "release": {
-    "branches": [
-      "release"
-    ]
-  },
-  "publishConfig": {
-    "access": "public"
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": false
+    },
+    "react-native": {
+      "optional": false
+    },
+    "react-native-svg": {
+      "optional": false
+    }
   },
   "packageManager": "yarn@3.2.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2677,6 +2677,13 @@ __metadata:
     react: ">=16.8.0"
     react-native: ">=0.50.0"
     react-native-svg: ">=12.1.0"
+  peerDependenciesMeta:
+    react:
+      optional: false
+    react-native:
+      optional: false
+    react-native-svg:
+      optional: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR refactors the release.yml workflow to be triggered on a push to the `release` branch. At the same time, we reuse the `ci.yml` workflow as a requirement for the `deploy:` job.

**Pipeline Test:** https://github.com/stackbuilders/react-native-spotlight-tour/actions/runs/3439395566

**Reference:** https://docs.github.com/en/actions/using-workflows/reusing-workflows