### PR TITLE
chore(tslint): Improve linter rules

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -6,7 +6,7 @@ import {
   SpotlightTourProvider,
   TourBox,
   TourStep,
-  useSpotlightTour
+  useSpotlightTour,
 } from "@stackbuilders/react-native-spotlight-tour";
 import React, { useRef } from "react";
 import { Animated, Button, Dimensions, SafeAreaView, Text } from "react-native";
@@ -17,7 +17,7 @@ import {
   DescriptionText,
   SectionContainerView,
   SpotDescriptionView,
-  TitleText
+  TitleText,
 } from "./App.styles";
 
 export const App: React.FC = () => {
@@ -37,7 +37,7 @@ export const App: React.FC = () => {
           <Button title="Next" onPress={next} />
         </ButtonsGroupView>
       </SpotDescriptionView>
-    )
+    ),
   }, {
     alignTo: Align.SCREEN,
     position: Position.BOTTOM,
@@ -60,7 +60,7 @@ export const App: React.FC = () => {
           </ButtonsGroupView>
         </SpotDescriptionView>
       );
-    }
+    },
   },
   {
     alignTo: Align.SCREEN,
@@ -78,21 +78,18 @@ export const App: React.FC = () => {
           {"If you want to go to the previous step, press "}<BoldText>{"Previous.\n"}</BoldText>
         </Text>
       </TourBox>
-    )
+    ),
   }, {
     alignTo: Align.SCREEN,
     before() {
-      return new Promise<void>((resolve, reject) => {
+      return new Promise<void>(resolve => {
         Animated.spring(gap, {
           bounciness: 100,
           speed: 1,
           toValue: Dimensions.get("screen").height * 0.25,
-          useNativeDriver: false // Disabled as RNST does not use native driver either (for now)
+          useNativeDriver: false, // Translate animation not supported native by native driver
         })
-        .start(({ finished }) => finished
-          ? resolve()
-          : reject()
-        );
+        .start(() => resolve());
       });
     },
     position: Position.TOP,
@@ -113,7 +110,7 @@ export const App: React.FC = () => {
           <Button title="Finish" onPress={stop} />
         </ButtonsGroupView>
       </SpotDescriptionView>
-    )
+    ),
   }];
 
   return (

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1418,7 +1418,14 @@ __metadata:
     react: ">=16.8.0"
     react-native: ">=0.50.0"
     react-native-svg: ">=12.1.0"
-  checksum: e7a3abe847c65559e2eab01be0b781b7ae7268564e8221b4cac41dc6ebbcf576a1fd7d8a78b4843fe97af186467c59c7b5c3764f8204077d84304ff472d8d9e7
+  peerDependenciesMeta:
+    react:
+      optional: false
+    react-native:
+      optional: false
+    react-native-svg:
+      optional: false
+  checksum: 443a481498f6bdd0175922a0e9fc11d7bd3576686a2b0d0d421154648d67a7950d02612647ef1d35943cd76ad25001e5148575b358746d3e923063cd41939127
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "ts-jest": "^28.0.7",
     "tslint": "^6.1.3",
     "tslint-react": "^5.0.0",
+    "tslint-react-hooks": "^2.2.2",
     "typescript": "^4.7.4",
     "typescript-styled-plugin": "^0.18.2"
   },

--- a/src/lib/AttachStep.component.tsx
+++ b/src/lib/AttachStep.component.tsx
@@ -56,7 +56,7 @@ export function AttachStep({ children, fill = false, index }: AttachStepProps): 
         {React.cloneElement(
           children,
           rest,
-          children.props.children
+          children.props.children,
         )}
       </View>
     );
@@ -65,6 +65,6 @@ export function AttachStep({ children, fill = false, index }: AttachStepProps): 
   return React.cloneElement(
     children,
     { ...children.props, ref: childRef },
-    children.props?.children
+    children.props?.children,
   );
 }

--- a/src/lib/SpotlightTour.context.ts
+++ b/src/lib/SpotlightTour.context.ts
@@ -3,14 +3,14 @@ import { LayoutRectangle, Omit } from "react-native";
 
 export enum Align {
   SCREEN = "screen",
-  SPOT = "spot"
+  SPOT = "spot",
 }
 
 export enum Position {
   BOTTOM = "bottom",
   LEFT = "left",
   RIGHT = "right",
-  TOP = "top"
+  TOP = "top",
 }
 
 export type RenderProps = Pick<SpotlightTourCtx, "next" | "previous" | "stop"> & {
@@ -44,7 +44,7 @@ export const ZERO_SPOT: LayoutRectangle = {
   height: 0,
   width: 0,
   x: 0,
-  y: 0
+  y: 0,
 };
 
 export const SpotlightTourContext = createContext<SpotlightTourCtx>({
@@ -55,7 +55,7 @@ export const SpotlightTourContext = createContext<SpotlightTourCtx>({
   spot: ZERO_SPOT,
   start: () => undefined,
   steps: [],
-  stop: () => undefined
+  stop: () => undefined,
 });
 
 export function useSpotlightTour(): SpotlightTour {
@@ -67,6 +67,6 @@ export function useSpotlightTour(): SpotlightTour {
     next,
     previous,
     start,
-    stop
+    stop,
   };
 }

--- a/src/lib/SpotlightTour.provider.tsx
+++ b/src/lib/SpotlightTour.provider.tsx
@@ -52,14 +52,14 @@ export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTo
     overlayColor = "black",
     overlayOpacity = 0.45,
     steps,
-    nativeDriver = true
+    nativeDriver = true,
   } = props;
 
   const [current, setCurrent] = useState<number>();
   const [spot, setSpot] = useState(ZERO_SPOT);
 
   const overlay = useRef<TourOverlayRef>({
-    hideTooltip: () => Promise.resolve({ finished: false })
+    hideTooltip: () => Promise.resolve({ finished: false }),
   });
 
   const renderStep = useCallback((index: number): void => {
@@ -71,7 +71,7 @@ export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTo
 
       Promise.all([
         beforePromise,
-        overlay.current.hideTooltip()
+        overlay.current.hideTooltip(),
       ])
       .then(() => setCurrent(index));
     }
@@ -123,7 +123,7 @@ export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTo
     spot,
     start,
     steps,
-    stop
+    stop,
   };
 
   useImperativeHandle(ref, () => ({
@@ -132,7 +132,7 @@ export const SpotlightTourProvider = React.forwardRef<SpotlightTour, SpotlightTo
     next,
     previous,
     start,
-    stop
+    stop,
   }));
 
   return (

--- a/src/lib/tour-box/TourBox.component.tsx
+++ b/src/lib/tour-box/TourBox.component.tsx
@@ -38,7 +38,7 @@ export function TourBox(props: TourBoxProps): ReactElement {
     isFirst,
     previous,
     stop,
-    next
+    next,
   } = props;
 
   const handleBack = () => {

--- a/src/lib/tour-overlay/TourOverlay.component.tsx
+++ b/src/lib/tour-overlay/TourOverlay.component.tsx
@@ -7,7 +7,7 @@ import React, {
   useImperativeHandle,
   useMemo,
   useRef,
-  useState
+  useState,
 } from "react";
 import {
   Animated,
@@ -16,7 +16,7 @@ import {
   LayoutRectangle,
   Modal,
   Platform,
-  ViewStyle
+  ViewStyle,
 } from "react-native";
 import { Circle, CircleProps, Defs, Mask, Rect, Svg } from "react-native-svg";
 
@@ -48,7 +48,7 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
     opacity,
     spot,
     tourStep,
-    nativeDriver
+    nativeDriver,
   } = props;
 
   const { next, previous, steps, stop } = useContext(SpotlightTourContext);
@@ -79,7 +79,7 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
     return Platform.select({
       android: driverConfig.android,
       default: false,
-      ios: driverConfig.ios
+      ios: driverConfig.ios,
     });
   }, [nativeDriver]);
 
@@ -93,7 +93,7 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
           ? Math.round(cx - (tipLayout.width / 2))
           : Math.round((vwDP(100) - tipLayout.width) / 2),
         marginTop: tipMargin,
-        top: Math.round(cy + r)
+        top: Math.round(cy + r),
       };
 
       case Position.TOP: return {
@@ -101,19 +101,19 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
           ? Math.round(cx - (tipLayout.width / 2))
           : Math.round((vwDP(100) - tipLayout.width) / 2),
         marginBottom: tipMargin,
-        top: Math.round(cy - r - tipLayout.height)
+        top: Math.round(cy - r - tipLayout.height),
       };
 
       case Position.LEFT: return {
         left: Math.round(cx - r - tipLayout.width),
         marginRight: tipMargin,
-        top: Math.round(cy - (tipLayout.height / 2))
+        top: Math.round(cy - (tipLayout.height / 2)),
       };
 
       case Position.RIGHT: return {
         left: Math.round(cx + r),
         marginLeft: tipMargin,
-        top: Math.round(cy - (tipLayout.height / 2))
+        top: Math.round(cy - (tipLayout.height / 2)),
       };
     }
   }, [r, cx, cy, tourStep.position, tourStep.alignTo]);
@@ -131,21 +131,21 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
         mass: 5,
         stiffness: 300,
         toValue: { x: cx, y: cy },
-        useNativeDriver
+        useNativeDriver,
       }),
       Animated.spring(radius, {
         damping: 30,
         mass: 5,
         stiffness: 300,
         toValue: r,
-        useNativeDriver
+        useNativeDriver,
       }),
       Animated.timing(tipOpacity, {
         delay: 500,
         duration: 300,
         toValue: 1,
-        useNativeDriver
-      })
+        useNativeDriver,
+      }),
     ]);
 
     moveSpot.start(() => setTooltipStyle({ }));
@@ -158,14 +158,14 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
           Animated.timing(tipOpacity, {
             duration: 300,
             toValue: 0,
-            useNativeDriver
+            useNativeDriver,
           })
           .start(resolve);
         } else {
           resolve({ finished: true });
         }
       });
-    }
+    },
   }), [current !== undefined]);
 
   return (

--- a/test/helpers/TestTour.tsx
+++ b/test/helpers/TestTour.tsx
@@ -26,7 +26,7 @@ export const BASE_STEP: TourStep = {
         <Text>{"Stop"}</Text>
       </TouchableOpacity>
     </View>
-  )
+  ),
 };
 
 const TestComponent: React.FC = () => {
@@ -54,7 +54,7 @@ const TestComponent: React.FC = () => {
 export const TestScreen: React.FC<TestScreenProps> = ({ steps }) => {
   const defaultSteps = [
     BASE_STEP,
-    { ...BASE_STEP, position: Position.TOP }
+    { ...BASE_STEP, position: Position.TOP },
   ];
 
   return (

--- a/test/helpers/helper.ts
+++ b/test/helpers/helper.ts
@@ -28,7 +28,7 @@ export function checkValidIntersection(rectangle: Rectangle, circle: Circle): bo
 
   const rectangleCentroid = {
     x: rectangle.x + rectangle.width / 2,
-    y: rectangle.y + rectangle.height / 2
+    y: rectangle.y + rectangle.height / 2,
   };
 
   const circleDistanceX = Math.abs(circle.x - rectangleCentroid.x);
@@ -39,7 +39,7 @@ export function checkValidIntersection(rectangle: Rectangle, circle: Circle): bo
   const rectangleCircleCentroidXDistance = Math.pow(rectangleCentroid.x - circle.x, 2);
   const rectangleCircleCentroidYDistance = Math.pow(rectangleCentroid.y - circle.y, 2);
   const circleAndRectangleCentroidDistance = Math.sqrt(
-    rectangleCircleCentroidYDistance + rectangleCircleCentroidXDistance
+    rectangleCircleCentroidYDistance + rectangleCircleCentroidXDistance,
   );
 
   const isCircleRadiusShorterThanCentroidsDistance = circle.r <= circleAndRectangleCentroidDistance;
@@ -63,7 +63,7 @@ export function checkValidIntersection(rectangle: Rectangle, circle: Circle): bo
   const relativeCircleRectangleXDistance = Math.pow(circleDistanceX - rectangle.width / 2, 2);
   const relativeCircleRectangleYDistance = Math.pow(circleDistanceY - rectangle.height / 2, 2);
   const cornerDistance = Math.sqrt(
-    relativeCircleRectangleXDistance + relativeCircleRectangleYDistance
+    relativeCircleRectangleXDistance + relativeCircleRectangleYDistance,
   );
 
   const squaredCornerDistanceIsSmallerThanSquaredCircleRadius =
@@ -84,18 +84,18 @@ function isReactTestInstance(child: ReactTestInstance | string): child is ReactT
 }
 
 function isReactProps<T extends object>(
-  props: React.PropsWithChildren<T> | null
+  props: React.PropsWithChildren<T> | null,
 ): props is React.PropsWithChildren<T> {
   return typeof props === "object";
 }
 
 export function findPropsOnTestInstance(
   reactTestInstance: ReactTestInstance,
-  componentName: string
+  componentName: string,
 ): React.PropsWithChildren<ChildProps> {
   const findInsideChild = (
     childReactTestInstance: ReactTestInstance,
-    depth: number
+    depth: number,
   ): (React.PropsWithChildren<ChildProps> | null)[] => {
     if (!isReactTestInstance(childReactTestInstance) || depth <= 0) {
       return [null];
@@ -110,7 +110,7 @@ export function findPropsOnTestInstance(
     return children.map(nestedChild =>
       isReactTestInstance(nestedChild)
         ? findInsideChild(nestedChild, depth - 1)
-        : null
+        : null,
     );
   };
 

--- a/test/helpers/measures.ts
+++ b/test/helpers/measures.ts
@@ -9,12 +9,12 @@ export const viewMockMeasureData: MeasureOnSuccessCallbackParams = {
   height: 400,
   width: 200,
   x: 1,
-  y: 1
+  y: 1,
 };
 
 export const buttonMockMeasureData: MeasureOnSuccessCallbackParams = {
   height: 50,
   width: 100,
   x: 10,
-  y: 10
+  y: 10,
 };

--- a/test/helpers/native-mocks.ts
+++ b/test/helpers/native-mocks.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 import {
   Animated,
   MeasureInWindowOnSuccessCallback,
-  NativeMethods
+  NativeMethods,
 } from "react-native";
 
 import { MeasureOnSuccessCallbackParams } from "./measures";
@@ -14,9 +14,9 @@ export function mockNativeComponent(modulePath: string, mockMethods: NativeMetho
       : React.Component;
 
   const Component = class extends SuperClass {
-    static displayName: string = "Component";
+    public static displayName: string = "Component";
 
-    render() {
+    public render() {
       const name: string =
         OriginalComponent.displayName ||
         OriginalComponent.name ||
@@ -55,11 +55,11 @@ export const emptyNativeMethods: NativeMethods = {
   measureInWindow: jest.fn(),
   measureLayout: jest.fn(),
   refs: {},
-  setNativeProps: jest.fn()
+  setNativeProps: jest.fn(),
 };
 
 export function createMeasureMethod(
-  mockMeasureData: MeasureOnSuccessCallbackParams
+  mockMeasureData: MeasureOnSuccessCallbackParams,
 ): (callback: MeasureInWindowOnSuccessCallback) => void {
   return callback => {
     const { x, y, width, height } = mockMeasureData;
@@ -70,5 +70,5 @@ export function createMeasureMethod(
 export const emptyAnimationMethods: Animated.CompositeAnimation = {
   reset: () => undefined,
   start: () => undefined,
-  stop: () => undefined
+  stop: () => undefined,
 };

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -49,27 +49,27 @@ describe("[Integration] index.test.tsx", () => {
           nativeEvent: {
             layout: {
               height: viewMockMeasureData.height,
-              width: viewMockMeasureData.width
-            }
-          }
+              width: viewMockMeasureData.width,
+            },
+          },
         });
 
         await waitFor(() => getByTestId("Spot Svg"));
 
         const svgCircleProps = findPropsOnTestInstance(
           getByTestId("Spot Svg"),
-          "RNSVGCircle"
+          "RNSVGCircle",
         );
 
         const layoutIsOverlayByCircle = checkValidIntersection({
           height: viewMockMeasureData.height,
           width: viewMockMeasureData.width,
           x: viewMockMeasureData.x,
-          y: viewMockMeasureData.y
+          y: viewMockMeasureData.y,
         }, {
           r: svgCircleProps?.r,
           x: svgCircleProps?.cx,
-          y: svgCircleProps?.cy
+          y: svgCircleProps?.cy,
         });
 
         expect(layoutIsOverlayByCircle).toBeTrue();
@@ -90,9 +90,9 @@ describe("[Integration] index.test.tsx", () => {
           nativeEvent: {
             layout: {
               height: viewMockMeasureData.height,
-              width: viewMockMeasureData.width
-            }
-          }
+              width: viewMockMeasureData.width,
+            },
+          },
         });
 
         await waitFor(() => getByTestId("Spot Svg"));
@@ -104,7 +104,7 @@ describe("[Integration] index.test.tsx", () => {
             marginTop: "2%",
             opacity: 1,
             position: "absolute",
-            top: 431
+            top: 431,
           });
       });
     });
@@ -127,27 +127,27 @@ describe("[Integration] index.test.tsx", () => {
           nativeEvent: {
             layout: {
               height: buttonMockMeasureData.height,
-              width: buttonMockMeasureData.width
-            }
-          }
+              width: buttonMockMeasureData.width,
+            },
+          },
         });
 
         await waitFor(() => getByTestId("Spot Svg"));
 
         const svgCircleProps = findPropsOnTestInstance(
           getByTestId("Spot Svg"),
-          "RNSVGCircle"
+          "RNSVGCircle",
         );
 
         const layoutIsOverlayByCircle = checkValidIntersection({
           height: buttonMockMeasureData.height,
           width: buttonMockMeasureData.width,
           x: buttonMockMeasureData.x,
-          y: buttonMockMeasureData.y
+          y: buttonMockMeasureData.y,
         }, {
           r: svgCircleProps?.r,
           x: svgCircleProps?.cx,
-          y: svgCircleProps?.cy
+          y: svgCircleProps?.cy,
         });
 
         expect(layoutIsOverlayByCircle).toBeTrue();
@@ -172,9 +172,9 @@ describe("[Integration] index.test.tsx", () => {
           nativeEvent: {
             layout: {
               height: buttonMockMeasureData.height,
-              width: buttonMockMeasureData.width
-            }
-          }
+              width: buttonMockMeasureData.width,
+            },
+          },
         });
 
         await waitFor(() => getByTestId("Spot Svg"));
@@ -186,7 +186,7 @@ describe("[Integration] index.test.tsx", () => {
             marginBottom: "2%",
             opacity: 1,
             position: "absolute",
-            top: -79
+            top: -79,
           });
       });
     });
@@ -214,7 +214,7 @@ describe("[Integration] index.test.tsx", () => {
         const beforeSpy = jest.fn(() => undefined);
         const steps: TourStep[] = [
           BASE_STEP,
-          { ...BASE_STEP, before: beforeSpy }
+          { ...BASE_STEP, before: beforeSpy },
         ];
         const { getByText } = render(<TestScreen steps={steps} />);
 
@@ -242,7 +242,7 @@ describe("[Integration] index.test.tsx", () => {
           const beforeSpy = jest.fn(() => Promise.resolve());
           const steps: TourStep[] = [
             BASE_STEP,
-            { ...BASE_STEP, before: beforeSpy }
+            { ...BASE_STEP, before: beforeSpy },
           ];
           const { getByText } = render(<TestScreen steps={steps} />);
 
@@ -269,7 +269,7 @@ describe("[Integration] index.test.tsx", () => {
           const beforeSpy = jest.fn(() => Promise.reject(new Error("Fail!")));
           const steps: TourStep[] = [
             BASE_STEP,
-            { ...BASE_STEP, before: beforeSpy }
+            { ...BASE_STEP, before: beforeSpy },
           ];
           const { getByText, queryByText } = render(<TestScreen steps={steps} />);
 

--- a/test/lib/AttachStep.component.test.tsx
+++ b/test/lib/AttachStep.component.test.tsx
@@ -28,7 +28,7 @@ describe("[Integration] AttachStep.component.test.tsx", () => {
           <AttachStep index={0}>
             <NativeText />
           </AttachStep>
-        </SpotlightTourProvider>
+        </SpotlightTourProvider>,
       );
 
       await waitFor(() => getByText("Native Text"));
@@ -44,12 +44,12 @@ describe("[Integration] AttachStep.component.test.tsx", () => {
           <AttachStep index={0}>
             <CustomText />
           </AttachStep>
-        </SpotlightTourProvider>
+        </SpotlightTourProvider>,
       );
 
       await waitFor(() =>
         within(getByTestId("attach-wrapper-view"))
-          .getByText("Custom Text")
+          .getByText("Custom Text"),
       );
     });
   });

--- a/test/lib/tour-overlay/TourOverlay.component.test.tsx
+++ b/test/lib/tour-overlay/TourOverlay.component.test.tsx
@@ -34,7 +34,7 @@ describe("[Integration] TourOverlay.component.test.tsx", () => {
       const { getByText } = render(
         <SpotlightTourProvider steps={STEPS}>
           <TestScreen />
-        </SpotlightTourProvider>
+        </SpotlightTourProvider>,
       );
 
       await waitFor(() => getByText("Step 1"));
@@ -46,7 +46,7 @@ describe("[Integration] TourOverlay.component.test.tsx", () => {
       const { getByText, queryByText } = render(
         <SpotlightTourProvider steps={STEPS}>
           <TestScreen />
-        </SpotlightTourProvider>
+        </SpotlightTourProvider>,
       );
 
       await waitFor(() => getByText("Step 1"));
@@ -64,7 +64,7 @@ describe("[Integration] TourOverlay.component.test.tsx", () => {
       const { getByText, queryByText } = render(
         <SpotlightTourProvider steps={STEPS}>
           <TestScreen />
-        </SpotlightTourProvider>
+        </SpotlightTourProvider>,
       );
 
       await waitFor(() => getByText("Step 1"));

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -5,14 +5,14 @@ import {
   isAnimatedValue,
   isAnimatedValueXY,
   isNumberValue,
-  isXYValue
+  isXYValue,
 } from "./helpers/helper";
 import { buttonMockMeasureData, viewMockMeasureData } from "./helpers/measures";
 import {
   createMeasureMethod,
   emptyAnimationMethods,
   emptyNativeMethods,
-  mockNativeComponent
+  mockNativeComponent,
 } from "./helpers/native-mocks";
 
 global.context = describe;
@@ -21,23 +21,23 @@ jest.mock("react-native/Libraries/Animated/NativeAnimatedHelper")
   .mock("react-native/Libraries/Components/View/View", () => {
     return mockNativeComponent("react-native/Libraries/Components/View/View", {
       ...emptyNativeMethods,
-      measureInWindow: createMeasureMethod(viewMockMeasureData)
+      measureInWindow: createMeasureMethod(viewMockMeasureData),
     });
   })
   .mock("react-native/Libraries/Components/Button", () => {
     return mockNativeComponent("react-native/Libraries/Components/Button", {
       ...emptyNativeMethods,
-      measureInWindow: createMeasureMethod(buttonMockMeasureData)
+      measureInWindow: createMeasureMethod(buttonMockMeasureData),
     });
   })
   .doMock("react-native/Libraries/Animated/AnimatedImplementation", () => {
     const ActualAnimated = jest.requireActual(
-      "react-native/Libraries/Animated/AnimatedImplementation"
+      "react-native/Libraries/Animated/AnimatedImplementation",
     );
 
     const timingMock = (
       value: Animated.Value | Animated.ValueXY,
-      config: Animated.TimingAnimationConfig
+      config: Animated.TimingAnimationConfig,
     ): Animated.CompositeAnimation => {
 
       return {
@@ -57,13 +57,13 @@ jest.mock("react-native/Libraries/Animated/NativeAnimatedHelper")
             value.setValue(config.toValue);
           }
           callback?.({ finished: true });
-        }
+        },
       };
     };
 
     const springMock = (
       value: Animated.Value | Animated.ValueXY,
-      config: Animated.SpringAnimationConfig
+      config: Animated.SpringAnimationConfig,
     ): Animated.CompositeAnimation => {
       return {
         ...emptyAnimationMethods,
@@ -75,14 +75,14 @@ jest.mock("react-native/Libraries/Animated/NativeAnimatedHelper")
           }
 
           callback?.({ finished: true });
-        }
+        },
       };
     };
 
     return {
       ...ActualAnimated,
       spring: springMock,
-      timing: timingMock
+      timing: timingMock,
     };
   });
 

--- a/tslint.json
+++ b/tslint.json
@@ -2,21 +2,34 @@
   "defaultSeverity": "error",
   "extends": [
     "tslint:recommended",
-    "tslint-react"
+    "tslint-react",
+    "tslint-react-hooks"
   ],
-  "jsRules": {},
   "rules": {
+    "align": [true, "statements"],
     "array-type": false,
     "arrow-parens": [true, "ban-single-arg-parens"],
     "eofline": true,
     "indent": [true, "spaces", 2],
     "interface-name": false,
+    "jsx-alignment": true,
+    "jsx-curly-spacing": [true, "never"],
+    "jsx-equals-spacing": [true, "never"],
+    "jsx-key": true,
+    "jsx-no-bind": true,
+    "jsx-no-lambda": true,
     "jsx-no-multiline-js": false,
+    "jsx-no-string-ref": true,
+    "jsx-self-close": true,
     "jsx-space-before-trailing-slash": true,
+    "linebreak-style": [true, "LF"],
     "max-line-length": [true, 120],
+    "member-access": [true, "check-constructor"],
     "no-console": true,
+    "no-duplicate-imports": true,
     "no-namespace": [true, "allow-declarations"],
     "no-trailing-whitespace": true,
+    "no-unbound-method": false,
     "no-unused-expression": false,
     "only-arrow-functions": false,
     "object-literal-sort-keys": true,
@@ -41,14 +54,25 @@
     ],
     "trailing-comma": [true, {
       "singleline": "never",
-      "multiline": "never"
+      "multiline": {
+        "arrays": "always",
+        "objects": "always",
+        "functions": "always",
+        "imports": "always",
+        "exports": "always",
+        "typeLiterals": "always"
+      },
+      "esSpecCompliant": true
     }],
     "variable-name": [true, "allow-pascal-case", "allow-leading-underscore"]
   },
   "linterOptions": {
     "exclude": [
-      "node_modules/**/*",
-      "example/node_modules/**/*"
+      ".yarn/**/*",
+      "build/**/*",
+      "dist/**/*",
+      "example/node_modules/**/*",
+      "node_modules/**/*"
     ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2671,6 +2671,7 @@ __metadata:
     ts-jest: ^28.0.7
     tslint: ^6.1.3
     tslint-react: ^5.0.0
+    tslint-react-hooks: ^2.2.2
     typescript: ^4.7.4
     typescript-styled-plugin: ^0.18.2
   peerDependencies:
@@ -10852,6 +10853,16 @@ __metadata:
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
+  languageName: node
+  linkType: hard
+
+"tslint-react-hooks@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "tslint-react-hooks@npm:2.2.2"
+  peerDependencies:
+    tslint: 5 - 6
+    typescript: ">=2.1.0"
+  checksum: 63afdb72620374e365e690a9e9ac163d630501bcbb11444738b72412b90f607803482017d8a2f09699dd836ea569a4357e1a562fdf0ede56be47694e3957a8bc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates a improves the linter rules. One notable change to consider is enforcing multiline trailing commas, as that syntax is already part of JavaScript and adopted by most JS developers.