### PR TITLE
feat(core): Add onStop callback to SpotLightTourProvider props

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -7,7 +7,7 @@ import {
   TourBox,
   TourStep,
 } from "@stackbuilders/react-native-spotlight-tour";
-import { OnStopBehavior } from "@stackbuilders/react-native-spotlight-tour/dist/lib/SpotlightTour.context";
+import { StopParams } from "@stackbuilders/react-native-spotlight-tour/dist/lib/SpotlightTour.context";
 import React, { ReactElement, useCallback, useMemo, useRef } from "react";
 import { Alert, Animated, Button, Dimensions, SafeAreaView, Text } from "react-native";
 
@@ -24,7 +24,7 @@ import { DocsTooltip } from "./DocsTooltip";
 export function App(): ReactElement {
   const gap = useRef(new Animated.Value(0)).current;
 
-  const onStopTour = useCallback(({ index, isLast }: OnStopBehavior) => {
+  const onStopTour = useCallback(({ index, isLast }: StopParams) => {
     Alert.alert(dedent`
         Step index: ${String(index)} \n
         Is last step: ${String(isLast)}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -7,8 +7,9 @@ import {
   TourBox,
   TourStep,
 } from "@stackbuilders/react-native-spotlight-tour";
-import { ReactElement, useMemo, useRef } from "react";
-import { Animated, Button, Dimensions, SafeAreaView, Text } from "react-native";
+import { OnStopBehavior } from "@stackbuilders/react-native-spotlight-tour/dist/lib/SpotlightTour.context";
+import { ReactElement, useCallback, useMemo, useRef } from "react";
+import { Alert, Animated, Button, Dimensions, SafeAreaView, Text } from "react-native";
 
 import {
   BoldText,
@@ -22,6 +23,14 @@ import { DocsTooltip } from "./DocsTooltip";
 
 export function App(): ReactElement {
   const gap = useRef(new Animated.Value(0)).current;
+
+  const onStopTour = useCallback(({ index, isLast }: OnStopBehavior) => {
+    Alert.alert(dedent`
+        Step index: ${String(index)} \n
+        Is last step: ${String(isLast)}
+      `,
+    );
+  }, []);
 
   const tourSteps = useMemo((): TourStep[] => [{
     alignTo: Align.SCREEN,
@@ -103,6 +112,7 @@ export function App(): ReactElement {
         nativeDriver={true}
         onBackdropPress="continue"
         motion="bounce"
+        onStop={onStopTour}
       >
         {({ start }) => (
           <>

--- a/package/src/lib/SpotlightTour.context.ts
+++ b/package/src/lib/SpotlightTour.context.ts
@@ -86,7 +86,7 @@ export type BackdropPressBehavior =
   | "stop"
   | ((options: SpotlightTour) => void);
 
-export interface OnStopBehavior {
+export interface StopParams {
   /**
    * Current step index.
    */

--- a/package/src/lib/SpotlightTour.context.ts
+++ b/package/src/lib/SpotlightTour.context.ts
@@ -80,6 +80,17 @@ export type BackdropPressBehavior =
   | "stop"
   | ((options: SpotlightTour) => void);
 
+export interface OnStopBehavior {
+  /**
+   * Current step index.
+   */
+  index: number;
+  /**
+   * `true` if the tour is on the last step, `false` otherwise.
+   */
+  isLast: boolean;
+}
+
 export interface TourStep {
   /**
    * Defines the tooltip alignment behavior:

--- a/package/src/lib/SpotlightTour.provider.tsx
+++ b/package/src/lib/SpotlightTour.provider.tsx
@@ -7,7 +7,7 @@ import {
   BackdropPressBehavior,
   Motion,
   OSConfig,
-  OnStopBehavior,
+  StopParams,
   Position,
   SpotlightTour,
   SpotlightTourContext,
@@ -55,12 +55,12 @@ export interface SpotlightTourProviderProps {
   onBackdropPress?: BackdropPressBehavior;
   /**
    * Handler which gets executed when {@link SpotlightTour.stop|stop} is
-   * invoked. It receives the {@link OnStopBehavior} so
+   * invoked. It receives the {@link StopParams} so
    * you can access the `current` step index where the tour stopped
    * and a bool value `isLast` indicating if the step where the tour stopped is
    * the last one.
    */
-  onStop?: (values: OnStopBehavior) => void;
+  onStop?: (values: StopParams) => void;
   /**
    * The color of the overlay of the tour.
    *

--- a/package/src/lib/SpotlightTour.provider.tsx
+++ b/package/src/lib/SpotlightTour.provider.tsx
@@ -7,6 +7,7 @@ import {
   BackdropPressBehavior,
   Motion,
   OSConfig,
+  OnStopBehavior,
   Position,
   SpotlightTour,
   SpotlightTourContext,
@@ -54,10 +55,12 @@ export interface SpotlightTourProviderProps {
   onBackdropPress?: BackdropPressBehavior;
   /**
    * Handler which gets executed when {@link SpotlightTour.stop|stop} is
-   * invoked. It receives the {@link SpotlightTour.current|current} step index
-   * so you can access the current step where the tour stopped.
+   * invoked. It receives the {@link OnStopBehavior} so
+   * you can access the `current` step index where the tour stopped
+   * and a bool value `isLast` indicating if the step where the tour stopped is
+   * the last one.
    */
-  onStop?: ((options: SpotlightTour["current"]) => void);
+  onStop?: (values: OnStopBehavior) => void;
   /**
    * The color of the overlay of the tour.
    *
@@ -119,10 +122,14 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
   }, [renderStep]);
 
   const stop = useCallback((): void => {
-    setCurrent(undefined);
+    setCurrent(prev => {
+      if (prev !== undefined) {
+        onStop?.({ index: prev, isLast: prev === steps.length - 1 });
+      }
+      return undefined;
+    });
     setSpot(ZERO_SPOT);
-    onStop?.(current);
-  }, [current, onStop]);
+  }, [onStop]);
 
   const next = useCallback((): void => {
     if (current !== undefined) {

--- a/package/src/lib/SpotlightTour.provider.tsx
+++ b/package/src/lib/SpotlightTour.provider.tsx
@@ -53,6 +53,12 @@ export interface SpotlightTourProviderProps {
    */
   onBackdropPress?: BackdropPressBehavior;
   /**
+   * Handler which gets executed when {@link SpotlightTour.stop|stop} is
+   * invoked. It receives the {@link SpotlightTour.current|current} step index
+   * so you can access the current step where the tour stopped.
+   */
+  onStop?: ((options: SpotlightTour["current"]) => void);
+  /**
    * The color of the overlay of the tour.
    *
    * @default black
@@ -82,6 +88,7 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
     steps,
     motion = "bounce",
     nativeDriver = true,
+    onStop,
   } = props;
 
   const [current, setCurrent] = useState<number>();
@@ -114,7 +121,8 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
   const stop = useCallback((): void => {
     setCurrent(undefined);
     setSpot(ZERO_SPOT);
-  }, []);
+    onStop?.(current);
+  }, [current, onStop]);
 
   const next = useCallback((): void => {
     if (current !== undefined) {

--- a/package/test/integration/index.test.tsx
+++ b/package/test/integration/index.test.tsx
@@ -191,7 +191,7 @@ describe("[Integration] index.test.tsx", () => {
     });
   });
 
-  describe("and the tour is stopped", () => {
+  describe("when the tour is stopped", () => {
     it("unmounts the overlay view", async () => {
       const { getByText, queryByTestId } = render(<TestScreen />);
 

--- a/package/test/integration/lib/tour-overlay/TourOverlay.component.test.tsx
+++ b/package/test/integration/lib/tour-overlay/TourOverlay.component.test.tsx
@@ -187,4 +187,24 @@ describe("[Integration] TourOverlay.component.test.tsx", () => {
       });
     });
   });
+
+  context("when a function is passed to the onStop prop in the tour provider", () => {
+    context("and the tour is stopped", () => {
+      it("invokes the function and injects the current index step", async() => {
+        const spy = Sinon.spy<(current: number | undefined) => void>(() => undefined);
+
+        const { getByText } = render(
+          <SpotlightTourProvider steps={STEPS} onStop={spy}>
+            <TestScreen />
+          </SpotlightTourProvider>,
+        );
+
+        await waitFor(() => getByText("Step 1"));
+
+        fireEvent.press(getByText("Stop"));
+
+        Sinon.assert.calledOnceWithExactly(spy, 0);
+      });
+    });
+  });
 });

--- a/package/test/integration/lib/tour-overlay/TourOverlay.component.test.tsx
+++ b/package/test/integration/lib/tour-overlay/TourOverlay.component.test.tsx
@@ -5,7 +5,7 @@ import { Text, View } from "react-native";
 import Sinon from "sinon";
 
 import { AttachStep, SpotlightTourProvider, TourStep, useSpotlightTour } from "../../../../src";
-import { OnStopBehavior, SpotlightTour } from "../../../../src/lib/SpotlightTour.context";
+import { StopParams, SpotlightTour } from "../../../../src/lib/SpotlightTour.context";
 import { BASE_STEP } from "../../../helpers/TestTour";
 
 const STEPS = Array.from<TourStep>({ length: 3 }).fill(BASE_STEP);
@@ -190,7 +190,7 @@ describe("[Integration] TourOverlay.component.test.tsx", () => {
 
   context("when a function is passed to the onStop prop in the tour provider", () => {
     it("invokes the function and injects the OnStopBehavior object in the values", async() => {
-      const spy = Sinon.spy<(values: OnStopBehavior) => void>(() => undefined);
+      const spy = Sinon.spy<(values: StopParams) => void>(() => undefined);
 
       const { getByText } = render(
         <SpotlightTourProvider steps={STEPS} onStop={spy}>
@@ -211,7 +211,7 @@ describe("[Integration] TourOverlay.component.test.tsx", () => {
     context("and the tour is stopped in the second step", () => {
       context("and the step is NOT the last one", () => {
         it("returns step index 1 and is last equals false", async() => {
-          const spy = Sinon.spy<(values: OnStopBehavior) => void>(() => undefined);
+          const spy = Sinon.spy<(values: StopParams) => void>(() => undefined);
 
           const { getByText } = render(
             <SpotlightTourProvider steps={STEPS} onStop={spy}>
@@ -238,7 +238,7 @@ describe("[Integration] TourOverlay.component.test.tsx", () => {
     context("and the tour is stopped in the third step", () => {
       context("and the step is the last one", () => {
         it("returns step index 2 and is last equals true", async() => {
-          const spy = Sinon.spy<(values: OnStopBehavior) => void>(() => undefined);
+          const spy = Sinon.spy<(values: StopParams) => void>(() => undefined);
 
           const { getByText } = render(
             <SpotlightTourProvider steps={STEPS} onStop={spy}>


### PR DESCRIPTION
This PR adds the possibility to run some events or actions after the tour stops by adding a new prop to the SpotLightTourProvider called onStop.
It solves issue #89