### PR TITLE
fix(core): Tooltip issues

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -34,7 +34,7 @@ export function App(): ReactElement {
   }, []);
 
   const tourSteps = useMemo((): TourStep[] => [{
-    floatingProps:{
+    floatingProps: {
       middleware: [offset(0), shift(), flip()],
       placement: "right",
     },

--- a/package/package.json
+++ b/package/package.json
@@ -35,7 +35,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@floating-ui/react-native": "^0.10.0",
+    "@floating-ui/react-native": "^0.10.1",
     "fast-equals": "^5.0.1",
     "react-native-responsive-dimensions": "^3.1.1",
     "styled-components": "^5.3.9"

--- a/package/src/lib/SpotlightTour.context.ts
+++ b/package/src/lib/SpotlightTour.context.ts
@@ -176,14 +176,6 @@ export interface SpotlightTourCtx extends SpotlightTour {
    */
   changeSpot: (spot: LayoutRectangle) => void;
   /**
-   * Specifies {@link FloatingProps} in order to configure Floating UI
-   * in all tour steps layout.
-   *
-   * @default middlewares: [flip(), offset(4), shift()]
-   * @default placement: "bottom"
-   */
-  floatingProps: FloatingProps;
-  /**
    * The spotlight layout.
    */
   spot: LayoutRectangle;
@@ -202,7 +194,6 @@ export const ZERO_SPOT: LayoutRectangle = {
 
 export const SpotlightTourContext = createContext<SpotlightTourCtx>({
   changeSpot: () => undefined,
-  floatingProps: {},
   goTo: () => undefined,
   next: () => undefined,
   previous: () => undefined,

--- a/package/src/lib/SpotlightTour.provider.tsx
+++ b/package/src/lib/SpotlightTour.provider.tsx
@@ -103,18 +103,16 @@ export interface SpotlightTourProviderProps {
   steps: TourStep[];
 }
 
-const DEFAULT_FLOATING_PROPS: FloatingProps = {
-  middleware: [flip(), offset(4), shift()],
-  placement: "bottom",
-};
-
 /**
  * React provider component to get access to the SpotlightTour context.
  */
 export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProviderProps>((props, ref) => {
   const {
     children,
-    floatingProps = DEFAULT_FLOATING_PROPS,
+    floatingProps = {
+      middleware: [flip(), offset(4), shift()],
+      placement: "bottom",
+    },
     motion = "bounce",
     nativeDriver = true,
     onBackdropPress,
@@ -187,15 +185,9 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
     return step ?? { floatingProps, render: () => <></> };
   }, [steps, current]);
 
-  const floatingUiConfigurations = useMemo(
-    (): FloatingProps => currentStep.floatingProps ?? floatingProps,
-    [floatingProps, currentStep],
-  );
-
   const tour = useMemo((): SpotlightTourCtx => ({
     changeSpot,
     current,
-    floatingProps: floatingUiConfigurations,
     goTo,
     next,
     previous,
@@ -203,7 +195,7 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
     start,
     steps,
     stop,
-  }), [changeSpot, current, floatingUiConfigurations, goTo, next, previous, spot, start, steps, stop]);
+  }), [changeSpot, current, goTo, next, previous, spot, start, steps, stop]);
 
   useImperativeHandle(ref, () => ({
     current,
@@ -225,6 +217,7 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
         backdropOpacity={overlayOpacity}
         color={overlayColor}
         current={current}
+        floatingProps={floatingProps}
         motion={motion}
         nativeDriver={nativeDriver}
         onBackdropPress={onBackdropPress}

--- a/package/src/lib/components/tour-overlay/TourOverlay.component.tsx
+++ b/package/src/lib/components/tour-overlay/TourOverlay.component.tsx
@@ -1,3 +1,4 @@
+import { useFloating } from "@floating-ui/react-native";
 import React, {
   forwardRef,
   useCallback,
@@ -20,6 +21,7 @@ import { Optional } from "../../../helpers/common";
 import { vhDP, vwDP } from "../../../helpers/responsive";
 import {
   BackdropPressBehavior,
+  FloatingProps,
   Motion,
   OSConfig,
   SpotlightTourContext,
@@ -37,6 +39,7 @@ interface TourOverlayProps {
   backdropOpacity: number;
   color: ColorValue;
   current: Optional<number>;
+  floatingProps: FloatingProps;
   motion: Motion;
   nativeDriver: boolean | OSConfig<boolean>;
   onBackdropPress: Optional<BackdropPressBehavior>;
@@ -50,6 +53,7 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
     backdropOpacity,
     color,
     current,
+    floatingProps,
     motion,
     nativeDriver,
     onBackdropPress,
@@ -58,7 +62,8 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
     tourStep,
   } = props;
 
-  const { goTo, next, previous, start, stop } = useContext(SpotlightTourContext);
+  const { goTo, next, previous, start, steps, stop } = useContext(SpotlightTourContext);
+  const { refs, floatingStyles } = useFloating(tourStep.floatingProps ?? floatingProps);
 
   const tooltipOpacity = useRef(new Animated.Value(0));
 
@@ -144,7 +149,7 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
             <Mask id="mask" x={0} y={0} height="100%" width="100%">
               <Rect height="100%" width="100%" fill="#fff" />
               <CircleShape
-                tourStep={tourStep}
+                setReference={refs.setReference}
                 motion={tourStep.motion ?? motion}
                 padding={padding}
                 useNativeDriver={useNativeDriver}
@@ -159,6 +164,26 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
             opacity={backdropOpacity}
           />
         </Svg>
+
+        {current !== undefined && (
+          <Animated.View
+            ref={refs.setFloating}
+            testID="Tooltip View"
+            style={{ ...floatingStyles, opacity: tooltipOpacity.current }}
+          >
+            <>
+              <tourStep.render
+                current={current}
+                isFirst={current === 0}
+                isLast={current === steps.length - 1}
+                next={next}
+                previous={previous}
+                stop={stop}
+                goTo={goTo}
+              />
+            </>
+          </Animated.View>
+        )}
       </OverlayView>
     </Modal>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,7 +1775,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/react-native@npm:^0.10.0":
+"@floating-ui/react-native@npm:^0.10.1":
   version: 0.10.1
   resolution: "@floating-ui/react-native@npm:0.10.1"
   dependencies:
@@ -3298,7 +3298,7 @@ __metadata:
   dependencies:
     "@babel/core": ^7.21.3
     "@babel/preset-env": ^7.20.2
-    "@floating-ui/react-native": ^0.10.0
+    "@floating-ui/react-native": ^0.10.1
     "@stackbuilders/assertive-ts": ^1.2.0
     "@testing-library/jest-native": ^5.4.2
     "@testing-library/react-native": ^11.5.4


### PR DESCRIPTION
This PR fixes a few tooltip issues. The main one was that the tooltip view was rendered within the `CircleShape` component, so the overlay was always on top of the tooltip, and it was not possible to interact with it.