### PR TITLE
feat(package): Rename package to react-native-spotlight-tour

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ yarn add @stackbuilders/react-native-spotlight-tour
 To be able to use the tour, you'll need to wrap everything around a `SpotlightTourProvider`. This provider component will also give you access to a hook to retrieve the `SpotlightTour` context, which gives information and fine control over the tour.
 
 ```tsx
-import { AttachStep, SpotlightTourProvider, TourStep } from "@stackbuilders/react-native-spotlight-tour";
+import { AttachStep, SpotlightTourProvider, TourStep } from "react-native-spotlight-tour";
 
 const mySteps: TourStep[] = [
   // ...
@@ -106,7 +106,7 @@ import {
   Align,
   TourStep,
   useSpotlightTour
-} from "@stackbuilders/react-native-spotlight-tour";
+} from "react-native-spotlight-tour";
 
 const mySteps: TourStep[] = [{
   // This configurations will apply just for this step
@@ -155,7 +155,7 @@ import {
   Align,
   TourBox,
   TourStep,
-} from "@stackbuilders/react-native-spotlight-tour";
+} from "react-native-spotlight-tour";
 
 const tourSteps: TourStep[] = [{
     render: props => (

--- a/example/package.json
+++ b/example/package.json
@@ -19,11 +19,11 @@
   "packageManager": "yarn@3.6.3",
   "dependencies": {
     "@cometlib/dedent": "^0.8.0-es.10",
-    "@stackbuilders/react-native-spotlight-tour": "workspace:^",
     "react": "18.2.0",
     "react-dom": "^18.2.0",
     "react-is": "^18.2.0",
     "react-native": "0.72.4",
+    "react-native-spotlight-tour": "workspace:^",
     "react-native-svg": "^13.13.0",
     "react-native-web": "^0.19.8",
     "styled-components": "^6.0.8"

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,4 +1,6 @@
 import dedent from "@cometlib/dedent";
+import React, { ReactElement, useCallback, useMemo, useRef } from "react";
+import { Alert, Animated, Button, Dimensions, SafeAreaView, Text } from "react-native";
 import {
   AttachStep,
   SpotlightTourProvider,
@@ -8,9 +10,7 @@ import {
   offset,
   shift,
   StopParams,
-} from "@stackbuilders/react-native-spotlight-tour";
-import React, { ReactElement, useCallback, useMemo, useRef } from "react";
-import { Alert, Animated, Button, Dimensions, SafeAreaView, Text } from "react-native";
+} from "react-native-spotlight-tour";
 
 import {
   BoldText,

--- a/example/src/DocsTooltip.tsx
+++ b/example/src/DocsTooltip.tsx
@@ -1,6 +1,6 @@
-import { useSpotlightTour } from "@stackbuilders/react-native-spotlight-tour";
 import React, { ReactElement } from "react";
 import { Button } from "react-native";
+import { useSpotlightTour } from "react-native-spotlight-tour";
 
 import { BoldText, ButtonsGroupView, DescriptionText, SpotDescriptionView } from "./App.styles";
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "turbo build",
     "check": "turbo check && yarn lint",
     "compile": "turbo compile",
-    "docs": "yarn workspace @stackbuilders/react-native-spotlight-tour docs",
+    "docs": "yarn workspace react-native-spotlight-tour docs",
     "ios": "yarn workspace example ios",
     "lint": "eslint .",
     "start": "turbo start",

--- a/package/package.json
+++ b/package/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stackbuilders/react-native-spotlight-tour",
+  "name": "react-native-spotlight-tour",
   "version": "0.0.0",
   "description": "React Native library to implement a highly customizable app tour feature with an awesome spotlight effect",
   "repository": "git@github.com:stackbuilders/react-native-spotlight-tour.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3572,53 +3572,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stackbuilders/react-native-spotlight-tour@workspace:^, @stackbuilders/react-native-spotlight-tour@workspace:package":
-  version: 0.0.0-use.local
-  resolution: "@stackbuilders/react-native-spotlight-tour@workspace:package"
-  dependencies:
-    "@assertive-ts/core": ^2.0.0
-    "@babel/core": ^7.22.20
-    "@babel/preset-env": ^7.22.20
-    "@floating-ui/react-native": ^0.10.1
-    "@testing-library/react-native": ^12.3.0
-    "@types/jest": ^29.5.5
-    "@types/node": ^20.6.2
-    "@types/react-test-renderer": ^18.0.2
-    "@types/sinon": ^10.0.16
-    babel-jest: ^29.7.0
-    expect-type: ^0.16.0
-    jest: ^29.7.0
-    metro-react-native-babel-preset: ^0.77.0
-    react: ^18.2.0
-    react-fast-compare: ^3.2.2
-    react-is: ^18.2.0
-    react-native: 0.72.4
-    react-native-responsive-dimensions: ^3.1.1
-    react-native-svg: ^13.13.0
-    react-test-renderer: ^18.2.0
-    semantic-release: ^22.0.0
-    sinon: ^16.0.0
-    styled-components: ^6.0.8
-    ts-jest: ^29.1.1
-    ts-node: ^10.9.1
-    typedoc: ^0.25.1
-    typedoc-plugin-markdown: ^3.16.0
-    typedoc-plugin-merge-modules: ^5.1.0
-    typescript: ^5.2.2
-  peerDependencies:
-    react: ">=16.8.0"
-    react-native: ">=0.50.0"
-    react-native-svg: ">=12.1.0"
-  peerDependenciesMeta:
-    react:
-      optional: false
-    react-native:
-      optional: false
-    react-native-svg:
-      optional: false
-  languageName: unknown
-  linkType: soft
-
 "@styled/typescript-styled-plugin@npm:^1.0.0":
   version: 1.0.0
   resolution: "@styled/typescript-styled-plugin@npm:1.0.0"
@@ -6921,13 +6874,13 @@ __metadata:
     "@rnx-kit/cli": ^0.16.14
     "@rnx-kit/metro-config": ^1.3.9
     "@rnx-kit/metro-resolver-symlinks": ^0.1.32
-    "@stackbuilders/react-native-spotlight-tour": "workspace:^"
     "@types/react": ^18.2.22
     metro-react-native-babel-preset: ^0.77.0
     react: 18.2.0
     react-dom: ^18.2.0
     react-is: ^18.2.0
     react-native: 0.72.4
+    react-native-spotlight-tour: "workspace:^"
     react-native-svg: ^13.13.0
     react-native-web: ^0.19.8
     serve: ^14.2.1
@@ -12370,6 +12323,53 @@ __metadata:
     eslint-plugin-sonarjs: ^0.21.0
     turbo: ^1.10.14
     typescript: ^5.2.2
+  languageName: unknown
+  linkType: soft
+
+"react-native-spotlight-tour@workspace:^, react-native-spotlight-tour@workspace:package":
+  version: 0.0.0-use.local
+  resolution: "react-native-spotlight-tour@workspace:package"
+  dependencies:
+    "@assertive-ts/core": ^2.0.0
+    "@babel/core": ^7.22.20
+    "@babel/preset-env": ^7.22.20
+    "@floating-ui/react-native": ^0.10.1
+    "@testing-library/react-native": ^12.3.0
+    "@types/jest": ^29.5.5
+    "@types/node": ^20.6.2
+    "@types/react-test-renderer": ^18.0.2
+    "@types/sinon": ^10.0.16
+    babel-jest: ^29.7.0
+    expect-type: ^0.16.0
+    jest: ^29.7.0
+    metro-react-native-babel-preset: ^0.77.0
+    react: ^18.2.0
+    react-fast-compare: ^3.2.2
+    react-is: ^18.2.0
+    react-native: 0.72.4
+    react-native-responsive-dimensions: ^3.1.1
+    react-native-svg: ^13.13.0
+    react-test-renderer: ^18.2.0
+    semantic-release: ^22.0.0
+    sinon: ^16.0.0
+    styled-components: ^6.0.8
+    ts-jest: ^29.1.1
+    ts-node: ^10.9.1
+    typedoc: ^0.25.1
+    typedoc-plugin-markdown: ^3.16.0
+    typedoc-plugin-merge-modules: ^5.1.0
+    typescript: ^5.2.2
+  peerDependencies:
+    react: ">=16.8.0"
+    react-native: ">=0.50.0"
+    react-native-svg: ">=12.1.0"
+  peerDependenciesMeta:
+    react:
+      optional: false
+    react-native:
+      optional: false
+    react-native-svg:
+      optional: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
BREAKING CHANGE: This package has been renamed `react-native-spotlight-tour` to make its usage more straightforward and explicit. This change also helps build tools and exclusion patterns, making it easier to be part of regular expressions that aim to exclude or transform all react-native packages (e.g., working with react-native-web).