### PR TITLE
chore(release): Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,7 @@
 name: Release
 
 on:
-  push:
-    branches: [release]
+  workflow_dispatch:
 
 concurrency:
   group: release
@@ -16,6 +15,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [build]
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -24,10 +28,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: yarn
       - run: yarn install --immutable
+      - run: yarn build
       - run: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   pages:
     uses: ./.github/workflows/pages.yml

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-sonarjs": "^0.21.0",
+    "semantic-release-yarn": "^2.0.1",
     "turbo": "^1.10.14",
     "typescript": "^5.2.2"
   }

--- a/package/.releaserc.json
+++ b/package/.releaserc.json
@@ -1,5 +1,10 @@
 {
-  "branches": [
-    "release"
+  "$schema": "https://json.schemastore.org/semantic-release",
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "semantic-release-yarn",
+    "@semantic-release/github"
   ]
 }

--- a/package/package.json
+++ b/package/package.json
@@ -59,7 +59,7 @@
     "react-native": "0.72.4",
     "react-native-svg": "^13.13.0",
     "react-test-renderer": "^18.2.0",
-    "semantic-release": "^22.0.0",
+    "semantic-release": "^22.0.1",
     "sinon": "^16.0.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3367,7 +3367,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@semantic-release/commit-analyzer@npm:^11.0.0-beta.3":
+"@semantic-release/commit-analyzer@npm:^11.0.0":
   version: 11.0.0
   resolution: "@semantic-release/commit-analyzer@npm:11.0.0"
   dependencies:
@@ -3440,7 +3440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@semantic-release/release-notes-generator@npm:^12.0.0-beta.2":
+"@semantic-release/release-notes-generator@npm:^12.0.0":
   version: 12.0.0
   resolution: "@semantic-release/release-notes-generator@npm:12.0.0"
   dependencies:
@@ -4211,7 +4211,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aggregate-error@npm:^4.0.0":
+"aggregate-error@npm:^4.0.0, aggregate-error@npm:^4.0.1":
   version: 4.0.1
   resolution: "aggregate-error@npm:4.0.1"
   dependencies:
@@ -5733,7 +5733,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cosmiconfig@npm:^8.0.0":
+"cosmiconfig@npm:^8.0.0, cosmiconfig@npm:^8.1.0":
   version: 8.3.6
   resolution: "cosmiconfig@npm:8.3.6"
   dependencies:
@@ -6923,7 +6923,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^8.0.0":
+"execa@npm:^8.0.0, execa@npm:^8.0.1":
   version: 8.0.1
   resolution: "execa@npm:8.0.1"
   dependencies:
@@ -7308,7 +7308,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^11.0.0":
+"fs-extra@npm:^11.0.0, fs-extra@npm:^11.1.0":
   version: 11.1.1
   resolution: "fs-extra@npm:11.1.1"
   dependencies:
@@ -12321,6 +12321,7 @@ __metadata:
     eslint-plugin-react: ^7.33.2
     eslint-plugin-react-hooks: ^4.6.0
     eslint-plugin-sonarjs: ^0.21.0
+    semantic-release-yarn: ^2.0.1
     turbo: ^1.10.14
     typescript: ^5.2.2
   languageName: unknown
@@ -12350,7 +12351,7 @@ __metadata:
     react-native-responsive-dimensions: ^3.1.1
     react-native-svg: ^13.13.0
     react-test-renderer: ^18.2.0
-    semantic-release: ^22.0.0
+    semantic-release: ^22.0.1
     sinon: ^16.0.0
     styled-components: ^6.0.8
     ts-jest: ^29.1.1
@@ -13032,15 +13033,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semantic-release@npm:^22.0.0":
-  version: 22.0.0
-  resolution: "semantic-release@npm:22.0.0"
+"semantic-release-yarn@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "semantic-release-yarn@npm:2.0.1"
   dependencies:
-    "@semantic-release/commit-analyzer": ^11.0.0-beta.3
+    "@semantic-release/error": ^4.0.0
+    aggregate-error: ^4.0.1
+    cosmiconfig: ^8.1.0
+    execa: ^8.0.1
+    fs-extra: ^11.1.0
+    js-yaml: ^4.1.0
+    lodash: ^4.17.21
+    nerf-dart: ^1.0.0
+    read-pkg: ^8.0.0
+    semver: ^7.3.8
+  peerDependencies:
+    semantic-release: ">=19.0.0"
+  checksum: d4acc0945241817adf533df30ffdd8384a4abe2853b6bb170b1fbb0bc97729c662dbcf97b12e0c83a2ded4737c9772b7c1fa23684b2cd3c840cc6bebdbf95069
+  languageName: node
+  linkType: hard
+
+"semantic-release@npm:^22.0.1":
+  version: 22.0.1
+  resolution: "semantic-release@npm:22.0.1"
+  dependencies:
+    "@semantic-release/commit-analyzer": ^11.0.0
     "@semantic-release/error": ^4.0.0
     "@semantic-release/github": ^9.0.0
     "@semantic-release/npm": ^11.0.0
-    "@semantic-release/release-notes-generator": ^12.0.0-beta.2
+    "@semantic-release/release-notes-generator": ^12.0.0
     aggregate-error: ^5.0.0
     cosmiconfig: ^8.0.0
     debug: ^4.0.0
@@ -13066,7 +13087,7 @@ __metadata:
     yargs: ^17.5.1
   bin:
     semantic-release: bin/semantic-release.js
-  checksum: bebb261eda691715f3368d5052557a5e82300477ae247a98e13391fbaca42380b2c15a9ac1164f4c0250a1810ab011a4c3155b260d3025369680e67f88b53f95
+  checksum: 2475af9ca2aca02d7efcf0c086b507a2126a79f08baeb2887f346575db1b34b17f27e749e7e3e2085dd6a56def4c159023be40a2b0f9af3b1fefb2d3cd7f0a70
   languageName: node
   linkType: hard
 
@@ -13104,7 +13125,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4":
+"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:


### PR DESCRIPTION
This PR updates the release workflow to improve semantic-release work with yarn workspaces. It also drops the usage of the `release` branch and makes things smoother by using the `main` branch and allowing on-demand dispatch of the release.yml workflow whenever we need to release.