### PR TITLE
docs(typedoc): Fix Docs Broken Url

### DIFF
--- a/package/typedoc.json
+++ b/package/typedoc.json
@@ -10,7 +10,7 @@
   "mergeModulesMergeMode": "project",
   "mergeModulesRenameDefaults": true,
   "name": "React Native Spotlight Tour - API Reference",
-  "out": "./docs/build",
+  "out": "../docs/build",
   "plugin": [
     "typedoc-plugin-markdown",
     "typedoc-plugin-merge-modules"


### PR DESCRIPTION
👋 Hey, I have fixed the issue #129 by editing the `package/typedoc.json` file. 🚀

As part of [Stack Builders Inc.](https://www.stackbuilders.com/) Hacktoberfest 2023 event.