### PR TITLE
Implement optional overlay on top of the spot

### DIFF
--- a/package/src/helpers/shape.ts
+++ b/package/src/helpers/shape.ts
@@ -8,6 +8,8 @@ interface RefNode {
 }
 
 export interface ShapeProps {
+  fill?: string | undefined;
+  fillOpacity?: number | undefined;
   motion: Motion;
   padding: number;
   setReference: (node?: RefNode) => void;

--- a/package/src/lib/SpotlightTour.context.ts
+++ b/package/src/lib/SpotlightTour.context.ts
@@ -101,6 +101,17 @@ export interface FloatingProps {
   sameScrollView?: boolean;
 }
 
+export interface SpotOverlayProps {
+  /**
+   * Fill colour for the overlay on top of the spot.
+   */
+  fill: string;
+  /**
+   * Fill opacity for the overlay on top of the spot.
+   */
+  fillOpacity?: number;
+}
+
 export interface TourStep {
   /**
    * Hook called right before the step starts. Useful to run effects or

--- a/package/src/lib/SpotlightTour.provider.tsx
+++ b/package/src/lib/SpotlightTour.provider.tsx
@@ -23,6 +23,7 @@ import {
   TourStep,
   ZERO_SPOT,
   FloatingProps,
+  SpotOverlayProps,
 } from "./SpotlightTour.context";
 import { TourOverlay, TourOverlayRef } from "./components/tour-overlay/TourOverlay.component";
 
@@ -98,6 +99,10 @@ export interface SpotlightTourProviderProps {
    */
   shape?: Shape;
   /**
+   * Define the props for an overlay on top of the spot, if applicable.
+   */
+  spotOverlayProps?: SpotOverlayProps;
+  /**
    * Defines the padding of the spot shape based on the wrapped component, so a
    * zero padding means the spot shape will fit exaclty around the wrapped
    * component. The padding value is a number in points.
@@ -128,6 +133,7 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
     overlayColor = "black",
     overlayOpacity = 0.45,
     shape = "circle",
+    spotOverlayProps,
     spotPadding = 16,
     steps,
   } = props;
@@ -234,6 +240,7 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
         ref={overlay}
         shape={shape}
         spot={spot}
+        spotOverlayProps={spotOverlayProps}
         tourStep={currentStep}
       />
     </SpotlightTourContext.Provider>

--- a/package/src/lib/components/tour-overlay/TourOverlay.component.tsx
+++ b/package/src/lib/components/tour-overlay/TourOverlay.component.tsx
@@ -27,6 +27,7 @@ import {
   Motion,
   OSConfig,
   Shape,
+  SpotOverlayProps,
   SpotlightTourContext,
   TourStep,
 } from "../../SpotlightTour.context";
@@ -50,6 +51,7 @@ interface TourOverlayProps {
   padding: number;
   shape: Shape;
   spot: LayoutRectangle;
+  spotOverlayProps?: SpotOverlayProps;
   tourStep: TourStep;
 }
 
@@ -65,6 +67,7 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
     padding,
     shape,
     spot,
+    spotOverlayProps,
     tourStep,
   } = props;
 
@@ -178,6 +181,17 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
               />
             </Mask>
           </Defs>
+          {spotOverlayProps &&
+            <ShapeMask
+              spot={spot}
+              setReference={refs.setReference}
+              motion={stepMotion}
+              padding={padding}
+              useNativeDriver={useNativeDriver}
+              fill={spotOverlayProps.fill}
+              fillOpacity={spotOverlayProps.fillOpacity}
+            />
+          }
           <Rect
             height="100%"
             width="100%"

--- a/package/src/lib/components/tour-overlay/shapes/CircleShape.component.tsx
+++ b/package/src/lib/components/tour-overlay/shapes/CircleShape.component.tsx
@@ -8,7 +8,7 @@ import { ShapeProps, transitionOf } from "../../../../helpers/shape";
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
 
 export const CircleShape = memo<ShapeProps>(props => {
-  const { motion, padding, setReference, spot, useNativeDriver } = props;
+  const { fill, fillOpacity, motion, padding, setReference, spot, useNativeDriver } = props;
 
   const r = useMemo((): number => {
     return Math.max(spot.width, spot.height) / 2 + padding;
@@ -60,7 +60,8 @@ export const CircleShape = memo<ShapeProps>(props => {
         cx={center.current.x}
         cy={center.current.y}
         opacity={opacity.current}
-        fill="black"
+        fill={fill ?? "black"}
+        fillOpacity={fillOpacity}
       />
     </>
   );

--- a/package/src/lib/components/tour-overlay/shapes/RectShape.component.tsx
+++ b/package/src/lib/components/tour-overlay/shapes/RectShape.component.tsx
@@ -8,7 +8,7 @@ import { ShapeProps, transitionOf } from "../../../../helpers/shape";
 const AnimatedRect = Animated.createAnimatedComponent(Rect);
 
 export const RectShape = memo<ShapeProps>(props => {
-  const { motion, padding, setReference, spot, useNativeDriver } = props;
+  const { fill, fillOpacity, motion, padding, setReference, spot, useNativeDriver } = props;
 
   const width = useMemo((): number => {
     return spot.width + padding;
@@ -59,7 +59,8 @@ export const RectShape = memo<ShapeProps>(props => {
       width={size.current.x}
       height={size.current.y}
       opacity={opacity.current}
-      fill="black"
+      fill={fill ?? "black"}
+      fillOpacity={fillOpacity}
       rx={4}
       ry={4}
     />


### PR DESCRIPTION
Was using this package at work and there was an additional use case to have an overlay on top of the "spotlight area" to improve the contrast with the background - I made a patch file to support this and figured to open a PR here too.

Thanks for this great package!