### PR TITLE
feat!(tooltip): Add tooltip arrow

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -6,9 +6,6 @@ import {
   SpotlightTourProvider,
   TourBox,
   TourStep,
-  flip,
-  offset,
-  shift,
   StopParams,
 } from "react-native-spotlight-tour";
 
@@ -36,10 +33,6 @@ export function App(): ReactElement {
   }, []);
 
   const tourSteps = useMemo((): TourStep[] => [{
-    floatingProps: {
-      middleware: [offset(0), shift(), flip()],
-      placement: "right",
-    },
     render: ({ next }) => (
       <SpotDescriptionView>
         <DescriptionText>
@@ -54,8 +47,8 @@ export function App(): ReactElement {
     ),
   }, {
     render: DocsTooltip,
-  },
-  {
+  }, {
+    arrow: true,
     render: props => (
       <TourBox
         title="Tour: Customization"
@@ -81,10 +74,6 @@ export function App(): ReactElement {
         })
         .start(() => resolve());
       });
-    },
-    floatingProps: {
-      middleware: [offset(4), shift()],
-      placement: "top",
     },
     render: ({ previous, stop }) => (
       <SpotDescriptionView>
@@ -113,14 +102,11 @@ export function App(): ReactElement {
         overlayColor={"gray"}
         overlayOpacity={0.36}
         nativeDriver={true}
-        floatingProps={{
-          middleware:[offset(5), shift(), flip()],
-          placement: "bottom",
-        }}
         onBackdropPress="continue"
         onStop={showSummary}
         motion="bounce"
         shape="circle"
+        arrow={{ color: "#B0C4DE" }}
       >
         {({ start }) => (
           <>

--- a/package/package.json
+++ b/package/package.json
@@ -39,7 +39,7 @@
   },
   "packageManager": "yarn@3.6.3",
   "dependencies": {
-    "@floating-ui/react-native": "^0.10.4",
+    "@floating-ui/react-native": "^0.10.6",
     "react-fast-compare": "^3.2.2",
     "react-native-responsive-dimensions": "^3.1.1",
     "styled-components": "^6.1.8"

--- a/package/src/helpers/common.ts
+++ b/package/src/helpers/common.ts
@@ -16,6 +16,13 @@ export type OmitR<
 export type Optional<T> = T | undefined;
 
 /**
+ * Transforms the value types of an object to be `Optional`.
+ */
+export type ToOptional<T> = {
+  [K in keyof Required<T>]: Optional<T[K]>;
+};
+
+/**
  * An alias of what a React child looks when passed as function.
  */
 export type ChildFn<T> = (value: T) => ReactNode;

--- a/package/src/lib/SpotlightTour.context.ts
+++ b/package/src/lib/SpotlightTour.context.ts
@@ -1,6 +1,6 @@
-import { Middleware, Placement } from "@floating-ui/react-native";
+import { FlipOptions, Placement, ShiftOptions } from "@floating-ui/react-native";
 import { createContext, ReactElement, useContext } from "react";
-import { LayoutRectangle } from "react-native";
+import { ColorValue, LayoutRectangle } from "react-native";
 
 /**
  * Possible motion effect for the tour spotlight:
@@ -81,27 +81,69 @@ export interface StopParams {
   isLast: boolean;
 }
 
+export interface ArrowOptions {
+  /**
+   * The color of the tooltip arrow.
+   *
+   * @default white
+   */
+  color?: ColorValue;
+  /**
+   * The rounding radius of the arrow tip.
+   *
+   * @default 2.5
+   */
+  corner?: number;
+  /**
+   * The size of the tooltip arrow.
+   *
+   * @default 16
+   */
+  size?: number;
+}
+
 /**
  * Configuration object which accepts Floating Ui
  * middleware, placement and sameScrollView configurations.
  */
-export interface FloatingProps {
+export interface TooltipProps {
   /**
-   * Array of middleware objects to modify the positioning or provide data for
-   * rendering.
+   * Tooltip arrow options. It accepts 3 types of value:
+   * - boolean: When `false`, disable rendering the arrow. While `true` renders
+   * using the default values.
+   * - number: Use it to change the size of the arrow only.
+   * - object: Options to further customize the arrow style.
+   *
+   * @default 20
    */
-  middleware?: Middleware[];
+  arrow?: number | boolean | ArrowOptions;
   /**
-   * Where to place the floating element relative to the reference element.
+   * Enables flipping the placement of the tooltip in order to keep it in view.
+   *
+   * @default true
+   */
+  flip?: FlipOptions | boolean;
+  /**
+   * Offset points between the tooltip and the spotlight.
+   *
+   * @default 4
+   */
+  offset?: number;
+  /**
+   * The placement of the tooltip relative to the spotlight.
+   *
+   * @default "bottom"
    */
   placement?: Placement;
   /**
-   * `true` for same scroll view, `false` otherwise.
+   * Enables shifting the tooltip in order to keep it in view.
+   *
+   * @default { padding: 8 }
    */
-  sameScrollView?: boolean;
+  shift?: ShiftOptions | boolean;
 }
 
-export interface TourStep {
+export interface TourStep extends TooltipProps {
   /**
    * Hook called right before the step starts. Useful to run effects or
    * animations required fo the step to show correctly. If a promise is
@@ -110,14 +152,6 @@ export interface TourStep {
    * @default undefined
    */
   before?: () => void | Promise<void>;
-  /**
-   * Specifies {@link FloatingProps} in order to configure Floating UI
-   * in a specific tour step layout.
-   *
-   * @default middlewares: [flip(), offset(4), shift()]
-   * @default placement: "bottom"
-   */
-  floatingProps?: FloatingProps;
   /**
    * Specifies the transition motion for the step. You can set the default
    * motion globally on the `SpotlightTourProvider` props too.

--- a/package/src/lib/SpotlightTour.provider.tsx
+++ b/package/src/lib/SpotlightTour.provider.tsx
@@ -1,4 +1,3 @@
-import { flip, offset, shift } from "@floating-ui/react-native";
 import React, {
   forwardRef,
   useCallback,
@@ -22,11 +21,11 @@ import {
   SpotlightTourCtx,
   TourStep,
   ZERO_SPOT,
-  FloatingProps,
+  TooltipProps,
 } from "./SpotlightTour.context";
 import { TourOverlay, TourOverlayRef } from "./components/tour-overlay/TourOverlay.component";
 
-export interface SpotlightTourProviderProps {
+export interface SpotlightTourProviderProps extends TooltipProps {
   /**
    * The children to render in the provider. It accepts either a React
    * component, or a function that returns a React component. When the child is
@@ -34,14 +33,6 @@ export interface SpotlightTourProviderProps {
    * argument.
    */
   children: React.ReactNode | ChildFn<SpotlightTour>;
-  /**
-   * Specifies {@link FloatingProps} in order to configure Floating UI
-   * in all tour steps layout.
-   *
-   * @default middlewares: [flip(), offset(4), shift()]
-   * @default placement: "bottom"
-   */
-  floatingProps?: FloatingProps;
   /**
    * Sets the default transition motion for all steps. You can override this
    * value on each step too.
@@ -116,11 +107,12 @@ export interface SpotlightTourProviderProps {
  */
 export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProviderProps>((props, ref) => {
   const {
+    arrow,
+    flip,
+    offset,
+    placement,
+    shift,
     children,
-    floatingProps = {
-      middleware: [flip(), offset(4), shift()],
-      placement: "bottom",
-    },
     motion = "bounce",
     nativeDriver = true,
     onBackdropPress,
@@ -191,7 +183,7 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
       ? steps[current]
       : undefined;
 
-    return step ?? { floatingProps, render: () => <></> };
+    return step ?? { render: () => <></> };
   }, [steps, current]);
 
   const tour = useMemo((): SpotlightTourCtx => ({
@@ -226,7 +218,6 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
         backdropOpacity={overlayOpacity}
         color={overlayColor}
         current={current}
-        floatingProps={floatingProps}
         motion={motion}
         nativeDriver={nativeDriver}
         onBackdropPress={onBackdropPress}
@@ -235,6 +226,11 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
         shape={shape}
         spot={spot}
         tourStep={currentStep}
+        arrow={arrow}
+        flip={flip}
+        offset={offset}
+        placement={placement}
+        shift={shift}
       />
     </SpotlightTourContext.Provider>
   );

--- a/package/src/lib/components/tour-overlay/TourOverlay.styles.ts
+++ b/package/src/lib/components/tour-overlay/TourOverlay.styles.ts
@@ -1,8 +1,110 @@
+import { Placement } from "@floating-ui/react-native";
+import { View } from "react-native";
+import { RuleSet, css } from "styled-components";
 import styled from "styled-components/native";
 
+import { Optional } from "../../../helpers/common";
 import { vh, vw } from "../../../helpers/responsive";
+import { ArrowOptions } from "../../SpotlightTour.context";
+
+interface Position {
+  x?: number;
+  y?: number;
+}
+
+interface TooltipArrowProps {
+  placement: Placement;
+  position: Optional<Position>;
+  size: Optional<number | ArrowOptions>;
+}
+
+export const DEFAULT_ARROW: Required<ArrowOptions> = {
+  color: "white",
+  corner: 2.5,
+  size: 16,
+};
 
 export const OverlayView = styled.View`
   height: ${vh(100)};
   width: ${vw(100)};
 `;
+
+export const TooltipArrow = styled(View)<TooltipArrowProps>`
+  background-color: transparent;
+  border-color: transparent;
+  box-sizing: content-box;
+  height: 0;
+  position: absolute;
+  width: 0;
+  z-index: -9999;
+
+  ${({ placement, position, size }) => arrowPosition({ placement, position, size })}
+`;
+
+function arrowPosition({
+  placement,
+  position = { },
+  size: sizeOrOption,
+}: TooltipArrowProps): RuleSet {
+  const { x = 0, y = 0 } = position;
+  const { color, corner, size } = typeof sizeOrOption === "number"
+    ? { ...DEFAULT_ARROW, size: sizeOrOption }
+    : { ...DEFAULT_ARROW, ...sizeOrOption };
+  const h = Math.sqrt(2 * size ** 2) / 2;
+  const height = -h + 0.5;
+
+  switch (placement) {
+    case "bottom":
+    case "bottom-end":
+    case "bottom-start":
+      return css`
+        border-bottom-width: ${size}px;
+        border-left-color: ${color.toString()};
+        border-left-width: ${size}px;
+        border-top-left-radius: ${corner}px;
+        left: ${x + h}px;
+        top: ${height}px;
+        transform: rotate(45deg);
+        transform-origin: top left;
+      `;
+    case "left":
+    case "left-end":
+    case "left-start":
+      return css`
+        border-bottom-width: ${size}px;
+        border-right-color: ${color.toString()};
+        border-right-width: ${size}px;
+        border-top-right-radius: ${corner}px;
+        right: ${height}px;
+        top: ${y + h}px;
+        transform: rotate(45deg);
+        transform-origin: top right;
+      `;
+    case "right":
+    case "right-end":
+    case "right-start":
+      return css`
+        border-bottom-left-radius: ${corner}px;
+        border-left-color: ${color.toString()};
+        border-left-width: ${size}px;
+        border-top-width: ${size}px;
+        bottom: ${y + h}px;
+        left: ${height}px;
+        transform: rotate(45deg);
+        transform-origin: bottom left;
+      `;
+    case "top":
+    case "top-end":
+    case "top-start":
+      return css`
+        border-bottom-left-radius: ${corner}px;
+        border-left-color: ${color.toString()};
+        border-left-width: ${size}px;
+        border-top-width: ${size}px;
+        bottom: ${height}px;
+        left: ${x + h}px;
+        transform: rotate(-45deg);
+        transform-origin: bottom left;
+      `;
+  }
+}

--- a/package/src/main.ts
+++ b/package/src/main.ts
@@ -1,7 +1,4 @@
-export {
-  ChildFn,
-  Optional,
-} from "./helpers/common";
+export { ChildFn, OmitR, Optional, ToOptional } from "./helpers/common";
 export {
   AttachStep,
   AttachStepProps,
@@ -13,13 +10,13 @@ export {
 } from "./lib/components/tour-box/TourBox.component";
 export {
   BackdropPressBehavior,
-  FloatingProps,
   Motion,
   OSConfig,
   RenderProps,
   Shape,
   SpotlightTour,
   StopParams,
+  TooltipProps,
   TourStep,
   useSpotlightTour,
 } from "./lib/SpotlightTour.context";

--- a/package/test/helpers/TestTour.tsx
+++ b/package/test/helpers/TestTour.tsx
@@ -9,9 +9,6 @@ interface TestScreenProps {
 }
 
 export const BASE_STEP: TourStep = {
-  floatingProps:{
-    placement: "bottom",
-  },
   render: ({ current, next, previous, stop }) => (
     <View>
       <Text>{`Step ${current + 1}`}</Text>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1285,31 +1285,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/core@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "@floating-ui/core@npm:1.6.0"
+"@floating-ui/core@npm:^1.0.0":
+  version: 1.6.4
+  resolution: "@floating-ui/core@npm:1.6.4"
   dependencies:
-    "@floating-ui/utils": "npm:^0.2.1"
-  checksum: 10/d6a47cacde193cd8ccb4c268b91ccc4ca254dffaec6242b07fd9bcde526044cc976d27933a7917f9a671de0a0e27f8d358f46400677dbd0c8199de293e9746e1
+    "@floating-ui/utils": "npm:^0.2.4"
+  checksum: 10/589430cbff4bac90b9b891e2c94c57dc113d39ac163552f547d9e4c7d21f09997b9d33e82ec717759caee678c47f845f14a3f28df6f029fcfcf3ad803ba4eb7c
   languageName: node
   linkType: hard
 
-"@floating-ui/react-native@npm:^0.10.4":
-  version: 0.10.4
-  resolution: "@floating-ui/react-native@npm:0.10.4"
+"@floating-ui/react-native@npm:^0.10.6":
+  version: 0.10.6
+  resolution: "@floating-ui/react-native@npm:0.10.6"
   dependencies:
-    "@floating-ui/core": "npm:^1.6.0"
+    "@floating-ui/core": "npm:^1.0.0"
   peerDependencies:
     react: ">=16.8.0"
     react-native: ">=0.64.0"
-  checksum: 10/39745c55e7acdc66b0c14312249d105d5afe8234631e24d8d2560cd8995e7e6c28bb0437ac84e90f3d79b9c05b31a224d445a15767b0f8709590cd3e087f4492
+  checksum: 10/e7ee9a2fb93674ad5b690b770de70989bb7dfd2e871ab698ec2259c7fa38047558fc8a21ad9138a16da95408bad9445b3ab7abec1fa54f3ad79a21a1a1ef033b
   languageName: node
   linkType: hard
 
-"@floating-ui/utils@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "@floating-ui/utils@npm:0.2.1"
-  checksum: 10/33c9ab346e7b05c5a1e6a95bc902aafcfc2c9d513a147e2491468843bd5607531b06d0b9aa56aa491cbf22a6c2495c18ccfc4c0344baec54a689a7bb8e4898d6
+"@floating-ui/utils@npm:^0.2.4":
+  version: 0.2.4
+  resolution: "@floating-ui/utils@npm:0.2.4"
+  checksum: 10/7662d7a4ae39c0287e026f666297a3d28c80e588251c8c59ff66938a0aead47d380bbb9018629bd63a98f399c3919ec689d5448a5c48ffc176d545ddef705df1
   languageName: node
   linkType: hard
 
@@ -10454,7 +10454,7 @@ __metadata:
   dependencies:
     "@assertive-ts/core": "npm:^2.1.0"
     "@assertive-ts/sinon": "npm:^1.0.0"
-    "@floating-ui/react-native": "npm:^0.10.4"
+    "@floating-ui/react-native": "npm:^0.10.6"
     "@testing-library/react-native": "npm:^12.4.4"
     "@types/mocha": "npm:^10.0.6"
     "@types/node": "npm:^20.11.28"


### PR DESCRIPTION
BREAKING CHANGE: The tooltip arrow now renders by default. FloatingUI-related props were refactored.
The `middleware` prop was removed, now you can either pass each supported middleware options or a boolean to enable/disable the feature controlled by each middleware.