### PR TITLE
fix: Add Android edge-to-edge display support

### DIFF
--- a/package/src/lib/components/tour-overlay/TourOverlay.styles.ts
+++ b/package/src/lib/components/tour-overlay/TourOverlay.styles.ts
@@ -1,6 +1,6 @@
+import { Dimensions } from "react-native";
 import { Platform, StyleSheet, type ViewStyle } from "react-native";
 
-import { vh, vw } from "../../../helpers/responsive";
 
 import type { Optional } from "../../../helpers/common";
 import type { ArrowOptions } from "../../SpotlightTour.context";
@@ -20,8 +20,11 @@ export const DEFAULT_ARROW: Required<ArrowOptions> = {
 
 export const Css = StyleSheet.create({
   overlayView: {
-    height: vh(100),
-    width: vw(100),
+    position: "absolute",
+    top: 0,
+    left: 0,
+    height: Dimensions.get("screen").height,
+    width: Dimensions.get("screen").width,
   },
   tooltipArrow: {
     backgroundColor: "transparent",


### PR DESCRIPTION
- Add statusBarTranslucent to Modal for proper full-screen coverage
- Replace vh/vw viewport units with Dimensions.get('screen') for accurate sizing
- Calculate adjustedSpot to account for status bar height offset
- Update styles with absolute positioning for proper overlay placement
- Fixes backdrop bleeding into status bar areas on Android edge-to-edge displays

Resolves issues where spotlight tour backdrop would not cover the entire screen and spotlight positioning would be offset by status bar height on Android devices with edge-to-edge display enabled.