### PR TITLE
fix: set for edge to edge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ local.properties
 
 # Packages
 *.tgz
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -34,7 +34,27 @@ for the following:
 
 ## ✨ Edge-to-Edge Support
 
-This library supports edge-to-edge display, including Android 15's enforced edge-to-edge mode. The tour overlay automatically covers the full screen including system bars. When using edge-to-edge layouts, you may need to adjust spotlight positioning using the `coordinateAdjustment` prop or individual `offset` props on `AttachStep` components. See the [example app](example/) for a working edge-to-edge implementation.
+This library supports edge-to-edge display (including Android 15’s enforced mode). The tour overlay already covers the whole screen, system bars included.
+
+When your screens use a translucent status bar you can enable proper handling—and optionally nudge the spotlight—via the new `translucentStatusBar` prop:
+
+```tsx
+<SpotlightTourProvider
+  translucentStatusBar={{
+    enable: true,                 // overlay under system bars
+    coordinateAdjustment: { y: insets.top }, // y = status-bar height (e.g. use SafeArea insets.top)
+  }}
+  {...otherProps}
+>
+  {/* … */}
+</SpotlightTourProvider>
+```
+
+`insets.top` is the height of the status bar returned by `react-native-safe-area-context`. Any value that represents the actual status-bar height will work.
+
+`translucentStatusBar` is **optional**—if you omit it or set `enable` to `false`, the tour continues to behave exactly as before.
+
+See the [example app](example/) for a fully-working edge-to-edge implementation.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ for the following:
 - [React Native](https://reactnative.dev/) >= 0.50.0
 - [react-native-svg](https://github.com/react-native-svg/react-native-svg) >= 12.1.0
 
+## ✨ Edge-to-Edge Support
+
+This library supports edge-to-edge display, including Android 15's enforced edge-to-edge mode. The tour overlay automatically covers the full screen including system bars. When using edge-to-edge layouts, you may need to adjust spotlight positioning using the `coordinateAdjustment` prop or individual `offset` props on `AttachStep` components. See the [example app](example/) for a working edge-to-edge implementation.
+
 ## Install
 
 With `npm`:

--- a/example/android/app/src/main/java/com/spotlightexample/MainActivity.kt
+++ b/example/android/app/src/main/java/com/spotlightexample/MainActivity.kt
@@ -1,11 +1,38 @@
 package com.spotlightexample
 
+import android.os.Build
+import android.os.Bundle
+import android.view.View
+import android.view.WindowInsetsController
+
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
 
 class MainActivity : ReactActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(null)
+
+        val window = window
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            // Edge-to-edge for Android 11+
+            window.setDecorFitsSystemWindows(false)
+            val controller = window.insetsController
+            controller?.systemBarsBehavior =
+                WindowInsetsController.BEHAVIOR_SHOW_BARS_BY_SWIPE
+        } else {
+            // Edge-to-edge for older versions
+            @Suppress("DEPRECATION")
+            window.decorView.systemUiVisibility = (
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                        or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+            )
+        }
+    }
 
   /**
    * Returns the name of the main component registered from JavaScript. This is used to schedule

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1648,6 +1648,96 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
+  - react-native-safe-area-context (5.6.1):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - react-native-safe-area-context/common (= 5.6.1)
+    - react-native-safe-area-context/fabric (= 5.6.1)
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - react-native-safe-area-context/common (5.6.1):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - react-native-safe-area-context/fabric (5.6.1):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - react-native-safe-area-context/common
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - React-NativeModulesApple (0.80.0):
     - boost
     - DoubleConversion
@@ -2226,6 +2316,7 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
+  - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-oscompat (from `../node_modules/react-native/ReactCommon/oscompat`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -2347,6 +2438,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   React-microtasksnativemodule:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
+  react-native-safe-area-context:
+    :path: "../node_modules/react-native-safe-area-context"
   React-NativeModulesApple:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios"
   React-oscompat:
@@ -2455,6 +2548,7 @@ SPEC CHECKSUMS:
   React-logger: b69e65dc60f768e5509ac0cc27a360124bf70478
   React-Mapbuffer: b48f9f3311fd0ec0f7a5dc39d707eff521fb5f38
   React-microtasksnativemodule: d8568d0485a350c720c061ae835e09fc88c28715
+  react-native-safe-area-context: fd72bd1eb562ff2a0fda20e9a7828c4b0cabf5a4
   React-NativeModulesApple: f10596688a03af66804cfbe61792be24a7888da8
   React-oscompat: 7c0a341cc31e350da71ddf2e46de0a845d1d1626
   React-perflogger: 4cc44451f694d6205f47bd8d5d87c9c862c3335c
@@ -2488,8 +2582,8 @@ SPEC CHECKSUMS:
   ReactCommon: 658874decaf8c4fd76cfa3a878b94a869db85b1c
   RNSVG: c73af7848d94ca3e8136a5191d055e3c1d6fedab
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 395b5d614cd7cbbfd76b05d01bd67230a6ad004e
+  Yoga: 0c4b7d2aacc910a1f702694fa86be830386f4ceb
 
 PODFILE CHECKSUM: 9742088751b8c39a438474c638da6274a8066e53
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/example/package.json
+++ b/example/package.json
@@ -26,6 +26,7 @@
     "react-dom": "19.1.0",
     "react-is": "19.1.0",
     "react-native": "0.80.0",
+    "react-native-safe-area-context": "^5.6.1",
     "react-native-spotlight-tour": "workspace:^",
     "react-native-svg": "^15.12.0",
     "react-native-svg-web": "^1.0.9",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,8 +1,11 @@
 import dedent from "dedent";
 import { type ReactElement, useCallback, useMemo } from "react";
-import { Alert, Animated, Button, Dimensions, SafeAreaView, Text, useAnimatedValue } from "react-native";
+import { Alert, Animated, Button, Dimensions, Platform, StatusBar, Text, View, useAnimatedValue } from "react-native";
+import { SafeAreaProvider, useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   AttachStep,
+  type RenderProps,
+  type SpotlightTour,
   SpotlightTourProvider,
   TourBox,
   type TourState,
@@ -19,8 +22,9 @@ import {
 } from "./App.styles";
 import { DocsTooltip } from "./DocsTooltip";
 
-export function App(): ReactElement {
+function AppContent(): ReactElement {
   const gap = useAnimatedValue(0, { useNativeDriver: true });
+  const insets = useSafeAreaInsets();
 
   const showSummary = useCallback(({ index, isLast }: TourState) => {
     Alert.alert(
@@ -40,7 +44,7 @@ export function App(): ReactElement {
   }, []);
 
   const tourSteps = useMemo((): TourStep[] => [{
-    render: ({ next, pause }) => (
+    render: ({ next, pause }: RenderProps) => (
       <SpotDescriptionView>
         <DescriptionText>
           <BoldText>{"Tour: Intro section\n"}</BoldText>
@@ -59,7 +63,7 @@ export function App(): ReactElement {
     render: DocsTooltip,
   }, {
     arrow: true,
-    render: props => (
+    render: (props: RenderProps) => (
       <TourBox
         title="Tour: Customization"
         backText="Previous"
@@ -92,7 +96,9 @@ export function App(): ReactElement {
           .start(() => resolve());
       });
     },
-    render: ({ previous, stop }) => (
+    flip: true,
+    placement: "top",
+    render: ({ previous, stop }: RenderProps) => (
       <SpotDescriptionView>
         <DescriptionText>
           <BoldText>{"Tour: Try it!\n"}</BoldText>
@@ -115,7 +121,12 @@ export function App(): ReactElement {
   }], []);
 
   return (
-    <SafeAreaView>
+    <View style={{
+      flex: 1,
+      paddingTop: insets.top,
+    }}
+    >
+      <StatusBar translucent={true} backgroundColor="transparent" barStyle="dark-content" />
       <SpotlightTourProvider
         steps={tourSteps}
         overlayColor="gray"
@@ -127,15 +138,16 @@ export function App(): ReactElement {
         motion="bounce"
         shape="circle"
         arrow={{ color: "#B0C4DE" }}
+        coordinateAdjustment={Platform.OS === "android" ? { y: insets.top } : undefined}
       >
-        {({ resume, start, status }) => (
+        {({ resume, start, status }: SpotlightTour) => (
           <>
             {status !== "paused" && <Button title="Start" onPress={start} />}
             {status === "paused" && <Button title="Resume" onPress={resume} />}
 
             <SectionContainerView>
-              <AttachStep index={1}>
-                <TitleText>{"Introduction"}</TitleText>
+              <AttachStep index={0}>
+                <TitleText>{"Introduction."}</TitleText>
               </AttachStep>
               <DescriptionText>
                 {dedent`
@@ -146,7 +158,7 @@ export function App(): ReactElement {
             </SectionContainerView>
 
             <SectionContainerView>
-              <AttachStep index={0}>
+              <AttachStep index={1}>
                 <TitleText>{"Documentation"}</TitleText>
               </AttachStep>
               <DescriptionText>
@@ -176,6 +188,14 @@ export function App(): ReactElement {
           </>
         )}
       </SpotlightTourProvider>
-    </SafeAreaView>
+    </View>
+  );
+}
+
+export function App(): ReactElement {
+  return (
+    <SafeAreaProvider>
+      <AppContent />
+    </SafeAreaProvider>
   );
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,7 @@
 import dedent from "dedent";
 import { type ReactElement, useCallback, useMemo } from "react";
-import { Alert, Animated, Button, Dimensions, Platform, StatusBar, Text, View, useAnimatedValue } from "react-native";
-import { SafeAreaProvider, useSafeAreaInsets } from "react-native-safe-area-context";
+import { Alert, Animated, Button, Dimensions, Text, useAnimatedValue } from "react-native";
+import { SafeAreaProvider, SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   AttachStep,
   type RenderProps,
@@ -24,8 +24,7 @@ import { DocsTooltip } from "./DocsTooltip";
 
 function AppContent(): ReactElement {
   const gap = useAnimatedValue(0, { useNativeDriver: true });
-  const insets = useSafeAreaInsets();
-
+  const { top } = useSafeAreaInsets();
   const showSummary = useCallback(({ index, isLast }: TourState) => {
     Alert.alert(
       "Tour Finished",
@@ -121,16 +120,11 @@ function AppContent(): ReactElement {
   }], []);
 
   return (
-    <View style={{
-      flex: 1,
-      paddingTop: insets.top,
-    }}
-    >
-      <StatusBar translucent={true} backgroundColor="transparent" barStyle="dark-content" />
+    <SafeAreaView style={{ flex: 1 }}>
       <SpotlightTourProvider
         steps={tourSteps}
         overlayColor="gray"
-        overlayOpacity={0.36}
+        overlayOpacity={0.86}
         nativeDriver={true}
         onBackdropPress="continue"
         onStop={showSummary}
@@ -138,7 +132,10 @@ function AppContent(): ReactElement {
         motion="bounce"
         shape="circle"
         arrow={{ color: "#B0C4DE" }}
-        coordinateAdjustment={Platform.OS === "android" ? { y: insets.top } : undefined}
+        translucentStatusBar={{
+          coordinateAdjustment: { y: top },
+          enable: true,
+        }}
       >
         {({ resume, start, status }: SpotlightTour) => (
           <>
@@ -188,7 +185,7 @@ function AppContent(): ReactElement {
           </>
         )}
       </SpotlightTourProvider>
-    </View>
+    </SafeAreaView>
   );
 }
 

--- a/example/src/DocsTooltip.tsx
+++ b/example/src/DocsTooltip.tsx
@@ -1,6 +1,6 @@
 import dedent from "dedent";
 import { Button } from "react-native";
-import { useSpotlightTour } from "react-native-spotlight-tour";
+import { type SpotlightTour, useSpotlightTour } from "react-native-spotlight-tour";
 
 import { BoldText, ButtonsGroupView, DescriptionText, SpotDescriptionView } from "./App.styles";
 
@@ -8,7 +8,7 @@ import type { ReactElement } from "react";
 
 export function DocsTooltip(): ReactElement {
   // You can also use the hook instead of the props here!
-  const { next, previous } = useSpotlightTour();
+  const { next, previous }: SpotlightTour = useSpotlightTour();
 
   return (
     <SpotDescriptionView>

--- a/package/src/lib/SpotlightTour.context.ts
+++ b/package/src/lib/SpotlightTour.context.ts
@@ -154,6 +154,11 @@ export interface TooltipProps {
    */
   arrow?: ArrowOptions | boolean | number;
   /**
+   * Global coordinate adjustment for all spotlight calculations.
+   * Useful for edge-to-edge layouts or custom status bar configurations.
+   */
+  coordinateAdjustment?: CoordinateAdjustment;
+  /**
    * Enables flipping the placement of the tooltip in order to keep it in view.
    *
    * @default true
@@ -272,6 +277,10 @@ export interface SpotlightTourCtx extends SpotlightTour {
    */
   changeSpot: (spot: LayoutRectangle) => void;
   /**
+   * Global coordinate adjustment for all spotlight calculations.
+   */
+  coordinateAdjustment?: CoordinateAdjustment;
+  /**
    * The spotlight layout.
    */
   spot: LayoutRectangle;
@@ -290,6 +299,7 @@ export const ZERO_SPOT: LayoutRectangle = {
 
 export const SpotlightTourContext = createContext<SpotlightTourCtx>({
   changeSpot: () => undefined,
+  coordinateAdjustment: undefined,
   goTo: () => undefined,
   next: () => undefined,
   pause: () => undefined,
@@ -321,4 +331,15 @@ export function useSpotlightTour(): SpotlightTour {
     status,
     stop,
   };
+}
+
+export interface CoordinateAdjustment {
+  /**
+   * Global X offset to apply to all spotlight calculations
+   */
+  x?: number;
+  /**
+   * Global Y offset to apply to all spotlight calculations
+   */
+  y?: number;
 }

--- a/package/src/lib/SpotlightTour.context.ts
+++ b/package/src/lib/SpotlightTour.context.ts
@@ -154,11 +154,6 @@ export interface TooltipProps {
    */
   arrow?: ArrowOptions | boolean | number;
   /**
-   * Global coordinate adjustment for all spotlight calculations.
-   * Useful for edge-to-edge layouts or custom status bar configurations.
-   */
-  coordinateAdjustment?: CoordinateAdjustment;
-  /**
    * Enables flipping the placement of the tooltip in order to keep it in view.
    *
    * @default true
@@ -182,6 +177,11 @@ export interface TooltipProps {
    * @default { padding: 8 }
    */
   shift?: boolean | ShiftOptions;
+  /**
+   * Global coordinate adjustment for all spotlight calculations.
+   * Useful for edge-to-edge layouts or custom status bar configurations.
+   */
+  translucentStatusBar?: TranslucentStatusBar;
 }
 
 export interface TourStep extends TooltipProps {
@@ -277,10 +277,6 @@ export interface SpotlightTourCtx extends SpotlightTour {
    */
   changeSpot: (spot: LayoutRectangle) => void;
   /**
-   * Global coordinate adjustment for all spotlight calculations.
-   */
-  coordinateAdjustment?: CoordinateAdjustment;
-  /**
    * The spotlight layout.
    */
   spot: LayoutRectangle;
@@ -288,6 +284,10 @@ export interface SpotlightTourCtx extends SpotlightTour {
    * The list of steps for the tour.
    */
   steps: TourStep[];
+  /**
+   * Global coordinate adjustment for all spotlight calculations.
+   */
+  translucentStatusBar?: TranslucentStatusBar;
 }
 
 export const ZERO_SPOT: LayoutRectangle = {
@@ -299,7 +299,6 @@ export const ZERO_SPOT: LayoutRectangle = {
 
 export const SpotlightTourContext = createContext<SpotlightTourCtx>({
   changeSpot: () => undefined,
-  coordinateAdjustment: undefined,
   goTo: () => undefined,
   next: () => undefined,
   pause: () => undefined,
@@ -310,6 +309,7 @@ export const SpotlightTourContext = createContext<SpotlightTourCtx>({
   status: "idle",
   steps: [],
   stop: () => undefined,
+  translucentStatusBar: undefined,
 });
 
 /**
@@ -332,7 +332,6 @@ export function useSpotlightTour(): SpotlightTour {
     stop,
   };
 }
-
 export interface CoordinateAdjustment {
   /**
    * Global X offset to apply to all spotlight calculations
@@ -342,4 +341,15 @@ export interface CoordinateAdjustment {
    * Global Y offset to apply to all spotlight calculations
    */
   y?: number;
+}
+export interface TranslucentStatusBar {
+  /**
+   * Global coordinate adjustment for all spotlight calculations.
+   */
+  coordinateAdjustment?: CoordinateAdjustment;
+  /**
+   * Whether to enable the translucent status bar
+   */
+  enable?: boolean;
+
 }

--- a/package/src/lib/SpotlightTour.provider.tsx
+++ b/package/src/lib/SpotlightTour.provider.tsx
@@ -116,7 +116,6 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
   const {
     arrow,
     children,
-    coordinateAdjustment,
     flip,
     motion = "bounce",
     nativeDriver = true,
@@ -131,6 +130,7 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
     shape = "circle",
     shift,
     steps,
+    translucentStatusBar,
   } = props;
 
   const [current, setCurrent] = useState<number>();
@@ -236,7 +236,6 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
 
   const tour = useMemo((): SpotlightTourCtx => ({
     changeSpot,
-    coordinateAdjustment,
     current,
     goTo,
     next,
@@ -248,7 +247,8 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
     status,
     steps,
     stop,
-  }), [changeSpot, coordinateAdjustment, current, goTo, next, previous, spot, start, steps, stop, pause]);
+    translucentStatusBar,
+  }), [changeSpot, translucentStatusBar, current, goTo, next, previous, spot, start, steps, stop, pause]);
 
   useImperativeHandle(ref, () => ({
     current,
@@ -270,7 +270,7 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
       }
 
       <TourOverlay
-        coordinateAdjustment={coordinateAdjustment}
+        translucentStatusBar={translucentStatusBar}
         backdropOpacity={overlayOpacity}
         color={overlayColor}
         current={current}

--- a/package/src/lib/SpotlightTour.provider.tsx
+++ b/package/src/lib/SpotlightTour.provider.tsx
@@ -116,6 +116,7 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
   const {
     arrow,
     children,
+    coordinateAdjustment,
     flip,
     motion = "bounce",
     nativeDriver = true,
@@ -235,6 +236,7 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
 
   const tour = useMemo((): SpotlightTourCtx => ({
     changeSpot,
+    coordinateAdjustment,
     current,
     goTo,
     next,
@@ -246,7 +248,7 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
     status,
     steps,
     stop,
-  }), [changeSpot, current, goTo, next, previous, spot, start, steps, stop, pause]);
+  }), [changeSpot, coordinateAdjustment, current, goTo, next, previous, spot, start, steps, stop, pause]);
 
   useImperativeHandle(ref, () => ({
     current,
@@ -268,6 +270,7 @@ export const SpotlightTourProvider = forwardRef<SpotlightTour, SpotlightTourProv
       }
 
       <TourOverlay
+        coordinateAdjustment={coordinateAdjustment}
         backdropOpacity={overlayOpacity}
         color={overlayColor}
         current={current}

--- a/package/src/lib/components/attach-step/AttachStep.component.tsx
+++ b/package/src/lib/components/attach-step/AttachStep.component.tsx
@@ -55,6 +55,14 @@ export interface AttachStepProps {
    */
   index: Array<number> | number;
   /**
+   * Local offset adjustment for this specific AttachStep.
+   * This will be added to any global coordinate adjustment.
+   */
+  offset?: {
+    x?: number;
+    y?: number;
+  };
+  /**
    * Style applied to AttachStep wrapper
    */
   style?: StyleProp<ViewStyle>;
@@ -67,8 +75,8 @@ export interface AttachStepProps {
  * @param props the component props
  * @returns an AttachStep React element
  */
-export function AttachStep({ children, fill = false, index, style }: AttachStepProps): ReactElement {
-  const { changeSpot, current } = useContext(SpotlightTourContext);
+export function AttachStep({ children, fill = false, index, offset, style }: AttachStepProps): ReactElement {
+  const { changeSpot, coordinateAdjustment, current } = useContext(SpotlightTourContext);
 
   const ref = useRef<View>(null);
 
@@ -77,10 +85,22 @@ export function AttachStep({ children, fill = false, index, style }: AttachStepP
 
     if (current !== undefined && indexes.includes(current)) {
       ref.current?.measureInWindow((x, y, width, height) => {
-        changeSpot({ height, width, x, y });
+        // Apply global coordinate adjustment
+        const globalX = coordinateAdjustment?.x || 0;
+        const globalY = coordinateAdjustment?.y || 0;
+
+        // Apply local offset
+        const localX = offset?.x || 0;
+        const localY = offset?.y || 0;
+
+        // Combine all adjustments
+        const adjustedX = x + globalX + localX;
+        const adjustedY = y + globalY + localY;
+
+        changeSpot({ height, width, x: adjustedX, y: adjustedY });
       });
     }
-  }, [changeSpot, current, JSON.stringify(index)]);
+  }, [changeSpot, current, JSON.stringify(index), coordinateAdjustment, offset]);
 
   const onLayout = useCallback((event: LayoutChangeEvent): void => {
     updateSpot();

--- a/package/src/lib/components/attach-step/AttachStep.component.tsx
+++ b/package/src/lib/components/attach-step/AttachStep.component.tsx
@@ -8,7 +8,7 @@ import {
   useEffect,
   useRef,
 } from "react";
-import { type LayoutChangeEvent, type StyleProp, View, type ViewStyle } from "react-native";
+import { type LayoutChangeEvent, Platform, type StyleProp, View, type ViewStyle } from "react-native";
 
 import { SpotlightTourContext } from "../../SpotlightTour.context";
 
@@ -55,14 +55,6 @@ export interface AttachStepProps {
    */
   index: Array<number> | number;
   /**
-   * Local offset adjustment for this specific AttachStep.
-   * This will be added to any global coordinate adjustment.
-   */
-  offset?: {
-    x?: number;
-    y?: number;
-  };
-  /**
    * Style applied to AttachStep wrapper
    */
   style?: StyleProp<ViewStyle>;
@@ -75,8 +67,9 @@ export interface AttachStepProps {
  * @param props the component props
  * @returns an AttachStep React element
  */
-export function AttachStep({ children, fill = false, index, offset, style }: AttachStepProps): ReactElement {
-  const { changeSpot, coordinateAdjustment, current } = useContext(SpotlightTourContext);
+export function AttachStep({ children, fill = false, index, style }: AttachStepProps):
+ReactElement {
+  const { changeSpot, current, translucentStatusBar } = useContext(SpotlightTourContext);
 
   const ref = useRef<View>(null);
 
@@ -85,22 +78,18 @@ export function AttachStep({ children, fill = false, index, offset, style }: Att
 
     if (current !== undefined && indexes.includes(current)) {
       ref.current?.measureInWindow((x, y, width, height) => {
-        // Apply global coordinate adjustment
+        if (!translucentStatusBar?.enable || Platform.OS === "ios") {
+          changeSpot({ height, width, x, y });
+          return;
+        }
+        const { coordinateAdjustment } = translucentStatusBar;
         const globalX = coordinateAdjustment?.x || 0;
         const globalY = coordinateAdjustment?.y || 0;
 
-        // Apply local offset
-        const localX = offset?.x || 0;
-        const localY = offset?.y || 0;
-
-        // Combine all adjustments
-        const adjustedX = x + globalX + localX;
-        const adjustedY = y + globalY + localY;
-
-        changeSpot({ height, width, x: adjustedX, y: adjustedY });
+        changeSpot({ height, width, x: x + globalX, y: y + globalY });
       });
     }
-  }, [changeSpot, current, JSON.stringify(index), coordinateAdjustment, offset]);
+  }, [changeSpot, current, JSON.stringify(index), translucentStatusBar]);
 
   const onLayout = useCallback((event: LayoutChangeEvent): void => {
     updateSpot();

--- a/package/src/lib/components/tour-overlay/TourOverlay.component.tsx
+++ b/package/src/lib/components/tour-overlay/TourOverlay.component.tsx
@@ -187,6 +187,7 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
       supportedOrientations={["portrait", "landscape", "landscape-left", "landscape-right", "portrait-upside-down"]}
       transparent={true}
       visible={current !== undefined}
+      statusBarTranslucent={true}
     >
       <View testID="Overlay View" style={Css.overlayView}>
         <Svg

--- a/package/src/lib/components/tour-overlay/TourOverlay.component.tsx
+++ b/package/src/lib/components/tour-overlay/TourOverlay.component.tsx
@@ -79,7 +79,9 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
     ...tooltipProps
   } = props;
 
-  const { goTo, next, pause, previous, resume, start, steps, stop } = useContext(SpotlightTourContext);
+  const {
+    goTo, next, pause, previous, resume, start, steps, stop, translucentStatusBar,
+  } = useContext(SpotlightTourContext);
 
   const arrowRef = useRef<View>(null);
 
@@ -187,7 +189,7 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
       supportedOrientations={["portrait", "landscape", "landscape-left", "landscape-right", "portrait-upside-down"]}
       transparent={true}
       visible={current !== undefined}
-      statusBarTranslucent={true}
+      statusBarTranslucent={translucentStatusBar?.enable ?? false}
     >
       <View testID="Overlay View" style={Css.overlayView}>
         <Svg

--- a/package/test/integration/main.test.tsx
+++ b/package/test/integration/main.test.tsx
@@ -1,14 +1,21 @@
 import { expect } from "@assertive-ts/core";
 import { fireEvent, render, userEvent, waitFor } from "@testing-library/react-native";
+import { Platform, Text, TouchableOpacity } from "react-native";
 import { mockNative, restoreNativeMocks } from "react-native-testing-mocks";
 import Sinon from "sinon";
 import { afterEach, describe, it, suite } from "vitest";
 
+import {
+  AttachStep,
+  SpotlightTourProvider,
+  type TourStep,
+  useSpotlightTour,
+} from "../../src/main";
 import { BASE_STEP, TestScreen } from "../helpers/TestTour";
 import { checkValidIntersection, findPropsOnTestInstance } from "../helpers/helper";
 import { buttonMockMeasureData, viewMockMeasureData } from "../helpers/measures";
 
-import type { TourStep } from "../../src/lib/SpotlightTour.context";
+import type React from "react";
 import type { CircleProps } from "react-native-svg";
 
 suite("[Integration] main.test.tsx", () => {
@@ -264,6 +271,88 @@ suite("[Integration] main.test.tsx", () => {
           expect(queryByText("Step 2")).toBeNull();
         });
       });
+    });
+  });
+
+  describe("when translucentStatusBar is enabled", () => {
+    it("applies the coordinateAdjustment to the spotlight position", async () => {
+      const ADJUST_Y = 50;
+
+      // Mock Platform.OS to be Android so coordinate adjustment applies
+      const originalOS = Platform.OS;
+      (Platform as { OS: string; }).OS = "android";
+
+      mockNative("View", {
+        measureInWindow: callback => {
+          const { height, width, x, y } = viewMockMeasureData;
+          callback(x, y, width, height);
+        },
+      });
+
+      const steps: TourStep[] = [BASE_STEP];
+
+      const CoordinateAdjustmentScreen = (): React.ReactElement => {
+        const TestComponent = (): React.ReactElement => {
+          const { start } = useSpotlightTour();
+
+          return (
+            <>
+              <AttachStep index={0}>
+                <Text>{"Test"}</Text>
+              </AttachStep>
+
+              <TouchableOpacity onPress={start}>
+                <Text>{"Start"}</Text>
+              </TouchableOpacity>
+            </>
+          );
+        };
+
+        return (
+          <SpotlightTourProvider
+            nativeDriver={false}
+            steps={steps}
+            translucentStatusBar={{ coordinateAdjustment: { y: ADJUST_Y }, enable: true }}
+          >
+            <TestComponent />
+          </SpotlightTourProvider>
+        );
+      };
+
+      const user = userEvent.setup();
+
+      const { findByTestId, findByText } = render(<CoordinateAdjustmentScreen />);
+
+      await user.press(await findByText("Start"));
+
+      // Wait for overlay to appear
+      await waitFor(() => findByTestId("Overlay View"));
+
+      // Wait until the tooltip text for step 1 is rendered
+      await waitFor(() => findByText("Step 1"));
+
+      const tooltip = await findByTestId("Tooltip View");
+
+      fireEvent(tooltip, "onLayout", {
+        nativeEvent: {
+          layout: {
+            height: viewMockMeasureData.height,
+            width: viewMockMeasureData.width,
+          },
+        },
+      });
+
+      const spotSvg = await findByTestId("Spot Svg");
+
+      await waitFor(() => {
+        const svgCircleProps = findPropsOnTestInstance<CircleProps>(spotSvg, "RNSVGCircle");
+
+        const expectedCy = viewMockMeasureData.y + viewMockMeasureData.height / 2 + ADJUST_Y;
+        expect(Number(svgCircleProps?.cy)).toBeEqual(expectedCy);
+      });
+
+      // Restore original Platform.OS
+      (Platform as { OS: string; }).OS = originalOS;
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7191,6 +7191,7 @@ __metadata:
     react-dom: "npm:19.1.0"
     react-is: "npm:19.1.0"
     react-native: "npm:0.80.0"
+    react-native-safe-area-context: "npm:^5.6.1"
     react-native-spotlight-tour: "workspace:^"
     react-native-svg: "npm:^15.12.0"
     react-native-svg-web: "npm:^1.0.9"
@@ -12047,6 +12048,16 @@ __metadata:
   peerDependencies:
     react-native: ">=0.44.1"
   checksum: 10/fa16d076bf81af486fc6f1eb50057574bc5f96f0e24a52b92f66a8af153e5a5f9e838cf942d1c26390273cceea1de894f0e214c232ec890875a82267f83a86f6
+  languageName: node
+  linkType: hard
+
+"react-native-safe-area-context@npm:^5.6.1":
+  version: 5.6.1
+  resolution: "react-native-safe-area-context@npm:5.6.1"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/2fc93cf46a6cbad28e5850bef009905c6db44066fb7e6f7bbce52c2ae4b0467c6718e4f572a42f8387c6b37f6d61ebe79980d0c2b5899e23dc19482a7db8417b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request is for the [issue](https://github.com/stackbuilders/react-native-spotlight-tour/issues/181) when using the spotlight tour on Android with edge to edge enabled, the overlay does not cover the full screen on android devices. 
Changes:
- Add support for Translucent statusBar
- Enable the possibility to pass an inset for the top on Android Platform in the case is Translucent statusBar is enable to be able to adjust the position (Adding the test for it)
- Update the example case to showcase how to use it and add it on the readme

