### PR TITLE
feat: Allow borderRadius prop for RectShape.

### DIFF
--- a/package/src/helpers/shape.ts
+++ b/package/src/helpers/shape.ts
@@ -7,6 +7,7 @@ interface RefNode {
 }
 
 export interface ShapeProps {
+  borderRadius: number;
   motion: Motion;
   padding: number;
   setReference: (node?: RefNode) => void;

--- a/package/src/lib/SpotlightTour.context.ts
+++ b/package/src/lib/SpotlightTour.context.ts
@@ -28,11 +28,18 @@ export type Shape = "circle" | "rectangle";
 
 export interface ShapeOptions {
   /**
+   * The rounding radius of the rectangle shape corners.
+   * Ignored if `type` is `"circle"`.
+   *
+   * @default 4
+   */
+  borderRadius?: number;
+  /**
    * The padding of the spot shape based on the wrapped component. A zero
    * padding means the spot shape will fit exactly around the wrapped
    * component. The padding value is a number in points.
    *
-   * @default 16;
+   * @default 16
    */
   padding?: number;
   /**

--- a/package/src/lib/components/tour-overlay/TourOverlay.component.tsx
+++ b/package/src/lib/components/tour-overlay/TourOverlay.component.tsx
@@ -106,10 +106,11 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
   const shapeOptions = useMemo((): Required<ShapeOptions> => {
     const options = tourStep.shape ?? shape;
     const padding = 16;
+    const borderRadius = 4;
 
     return typeof options !== "string"
-      ? { padding, type: "circle", ...options }
-      : { padding, type: options };
+      ? { borderRadius, padding, type: "circle", ...options }
+      : { borderRadius, padding, type: options };
   }, [tourStep, shape]);
 
   const useNativeDriver = useMemo(() => {
@@ -206,6 +207,7 @@ export const TourOverlay = forwardRef<TourOverlayRef, TourOverlayProps>((props, 
                 setReference={refs.setReference}
                 motion={stepMotion}
                 padding={shapeOptions.padding}
+                borderRadius={shapeOptions.borderRadius}
                 useNativeDriver={useNativeDriver}
               />
             </Mask>

--- a/package/src/lib/components/tour-overlay/shapes/RectShape.component.tsx
+++ b/package/src/lib/components/tour-overlay/shapes/RectShape.component.tsx
@@ -8,7 +8,7 @@ import { type ShapeProps, transitionOf } from "../../../../helpers/shape";
 const AnimatedRect = Animated.createAnimatedComponent(Rect);
 
 export const RectShape = memo<ShapeProps>(props => {
-  const { motion, padding, setReference, spot, useNativeDriver } = props;
+  const { borderRadius, motion, padding, setReference, spot, useNativeDriver } = props;
 
   const width = useMemo((): number => {
     return spot.width + padding;
@@ -60,8 +60,8 @@ export const RectShape = memo<ShapeProps>(props => {
       height={size.y}
       opacity={opacity}
       fill="black"
-      rx={4}
-      ry={4}
+      rx={borderRadius}
+      ry={borderRadius}
     />
   );
 }, isEqual);


### PR DESCRIPTION
This pull request introduces support for customizable corner rounding (border radius) for rectangle-shaped overlays in the spotlight tour feature. The main changes include extending the shape configuration interfaces and updating components to use the new `borderRadius` property, allowing for more flexible and visually appealing rectangle highlights.

**Shape configuration enhancements:**

* Added a `borderRadius` property to `ShapeProps` in `package/src/helpers/shape.ts` to support customizable corner rounding for shapes.
* Added a `borderRadius` option to `ShapeOptions` in `package/src/lib/SpotlightTour.context.ts`, including documentation and a default value of 4.

**Component and rendering updates:**

* Updated the shape options handling in `TourOverlay.component.tsx` to include `borderRadius` with a default value, ensuring it is passed to shape components.
* Passed the new `borderRadius` prop from `TourOverlay.component.tsx` to the shape component, enabling dynamic corner rounding.
* Modified `RectShape.component.tsx` to use the `borderRadius` prop for the rectangle's `rx` and `ry` SVG attributes, replacing the previous hardcoded value. [[1]](diffhunk://#diff-c228d14b816f075bec8d9ec5e0b8ee31ad3c406b2e62b340cd463439be4f7b37L11-R11) [[2]](diffhunk://#diff-c228d14b816f075bec8d9ec5e0b8ee31ad3c406b2e62b340cd463439be4f7b37L63-R64)