### PR TITLE
fix: typedoc links

### DIFF
--- a/package/typedoc.json
+++ b/package/typedoc.json
@@ -3,7 +3,7 @@
   "cleanOutputDir": true,
   "entryPoints": ["src/main.ts"],
   "entryPointStrategy": "expand",
-  "gitRevision": "release",
+  "gitRevision": "main",
   "githubPages": false,
   "hideGenerator": true,
   "includeVersion": false,


### PR DESCRIPTION
This pull request updates the `typedoc.json` file's configuration. The documentation generation will now use the `main` branch as the source for Git revision information instead of the `release` branch.

- Updated the `gitRevision` setting in `typedoc.json` to use the `main` branch for generating documentation.