### PR TITLE
Fix: Critical vulnerability in fast-xml-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "turbo": "^2.5.4",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.34.1"
+  },
+  "resolutions": {
+    "fast-xml-parser": "5.7.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7326,18 +7326,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:^4.0.0":
-  version: 4.5.3
-  resolution: "fast-xml-parser@npm:4.5.3"
-  dependencies:
-    strnum: "npm:^1.1.1"
-  bin:
-    fxparser: src/cli/cli.js
-  checksum: 10/ca22bf9d65c10b8447c1034c13403e90ecee210e2b3852690df3d8a42b8a46ec655fae7356096abd98a15b89ddaf11878587b1773e0c3be4cbc2ac4af4c7bf95
-  languageName: node
-  linkType: hard
-
-"fast-xml-parser@npm:^5.3.6":
+"fast-xml-parser@npm:5.7.3":
   version: 5.7.3
   resolution: "fast-xml-parser@npm:5.7.3"
   dependencies:
@@ -13773,13 +13762,6 @@ __metadata:
   dependencies:
     js-tokens: "npm:^9.0.1"
   checksum: 10/da1616f654f3ff481e078597b4565373a5eeed78b83de4a11a1a1b98292a9036f2474e528eff19b6eed93370428ff957a473827057c117495086436725d7efad
-  languageName: node
-  linkType: hard
-
-"strnum@npm:^1.1.1":
-  version: 1.1.2
-  resolution: "strnum@npm:1.1.2"
-  checksum: 10/ccd6297a1fdaf0fc8ea0ea904acdae76878d49a4b0d98a70155df4bc081fd88eac5ec99fb150f3d1d1af065c1898d38420705259ba6c39aa850c671bcd54e35d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR addresses the critical vulnerability in `fast-xml-parser` by forcing version `5.7.3` across all dependencies using Yarn resolutions.

This fixes the issue where `@rnx-kit/tools-apple` was pulling an older, vulnerable version.

Related Security Alert: [Dependabot #195](https://github.com/stackbuilders/react-native-spotlight-tour/security/dependabot/195)