### PR TITLE
 Fix: Critical JS injection vulnerability in handlebars

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7962,8 +7962,8 @@ __metadata:
   linkType: hard
 
 "handlebars@npm:^4.7.7":
-  version: 4.7.8
-  resolution: "handlebars@npm:4.7.8"
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: "npm:^1.2.5"
     neo-async: "npm:^2.6.2"
@@ -7975,7 +7975,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 10/bd528f4dd150adf67f3f857118ef0fa43ff79a153b1d943fa0a770f2599e38b25a7a0dbac1a3611a4ec86970fd2325a81310fb788b5c892308c9f8743bd02e11
+  checksum: 10/e755433d652e8a15fc02f83d7478e652359e7a4d354c4328818853ed4f8a39d4a09e1d22dad3c7213c5240864a65b3c840970b8b181745575dd957dd258f2b8d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR addresses the critical JS injection vulnerability in `handlebars` by upgrading to `4.7.9` version.

Related Security Alert: [Dependabot #216](https://github.com/stackbuilders/react-native-spotlight-tour/security/dependabot/216)