### PR TITLE
Fix: Upgrade sha.js to resolve vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13145,19 +13145,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sha.js@npm:^2.4.0, sha.js@npm:^2.4.8":
-  version: 2.4.11
-  resolution: "sha.js@npm:2.4.11"
-  dependencies:
-    inherits: "npm:^2.0.1"
-    safe-buffer: "npm:^5.0.1"
-  bin:
-    sha.js: ./bin.js
-  checksum: 10/d833bfa3e0a67579a6ce6e1bc95571f05246e0a441dd8c76e3057972f2a3e098465687a4369b07e83a0375a88703577f71b5b2e966809e67ebc340dbedb478c7
-  languageName: node
-  linkType: hard
-
-"sha.js@npm:^2.4.12":
+"sha.js@npm:^2.4.0, sha.js@npm:^2.4.12, sha.js@npm:^2.4.8":
   version: 2.4.12
   resolution: "sha.js@npm:2.4.12"
   dependencies:


### PR DESCRIPTION
This PR upgrades `sha.js` to version `2.4.12` to fix the active security advisory. 

Related Security Alert: [Dependabot#148](https://github.com/stackbuilders/react-native-spotlight-tour/security/dependabot/148)