### PR TITLE
Chore: Upgrade flatted to resolve prototype pollution vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7565,9 +7565,9 @@ __metadata:
   linkType: hard
 
 "flatted@npm:^3.2.9":
-  version: 3.3.3
-  resolution: "flatted@npm:3.3.3"
-  checksum: 10/8c96c02fbeadcf4e8ffd0fa24983241e27698b0781295622591fc13585e2f226609d95e422bcf2ef044146ffacb6b68b1f20871454eddf75ab3caa6ee5f4a1fe
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 10/a9e78fe5c2c1fcd98209a015ccee3a6caa953e01729778e83c1fe92e68601a63e1e69cd4e573010ca99eaf585a581b80ccf1018b99283e6cbc2117bcba1e030f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR upgrades `flatted` to version `3.4.2` to fix Prototype Pollution via parse()

Related Security Alert: [Dependabot#204](https://github.com/stackbuilders/react-native-spotlight-tour/security/dependabot/204)