### PR TITLE
Chore(example): Upgrade addressable gem to resolve ReDoS vulnerability

### DIFF
--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.6)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 6.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)


### PR DESCRIPTION
This PR upgrades `addressable` to version `2.9.0` to fix Regular Expression Denial of Service in Addressable templates.

Related Security Alert: [Dependabot#227](https://github.com/stackbuilders/react-native-spotlight-tour/security/dependabot/227)