### PR TITLE
chore: update semantic-release to v25.0.9

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -57,7 +57,7 @@
     "react-native-svg": "^15.12.0",
     "react-native-testing-mocks": "^1.7.0",
     "react-test-renderer": "19.2.3",
-    "semantic-release": "^25.0.8",
+    "semantic-release": "^25.0.9",
     "semantic-release-yarn": "^3.0.2",
     "sinon": "^21.0.0",
     "typedoc": "^0.28.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12314,7 +12314,7 @@ __metadata:
     react-native-svg: "npm:^15.12.0"
     react-native-testing-mocks: "npm:^1.7.0"
     react-test-renderer: "npm:19.2.3"
-    semantic-release: "npm:^25.0.8"
+    semantic-release: "npm:^25.0.9"
     semantic-release-yarn: "npm:^3.0.2"
     sinon: "npm:^21.0.0"
     typedoc: "npm:^0.28.5"
@@ -13123,9 +13123,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semantic-release@npm:^25.0.8":
-  version: 25.0.8
-  resolution: "semantic-release@npm:25.0.8"
+"semantic-release@npm:^25.0.9":
+  version: 25.0.9
+  resolution: "semantic-release@npm:25.0.9"
   dependencies:
     "@semantic-release/commit-analyzer": "npm:^13.0.1"
     "@semantic-release/error": "npm:^4.0.0"
@@ -13157,7 +13157,7 @@ __metadata:
     yargs: "npm:^18.0.0"
   bin:
     semantic-release: bin/semantic-release.js
-  checksum: 10/df6f5e800dee9a2379b60edc93393f1ee2003fba2037d938f4ccaeb17db3f1d2c864ee7d8b4d3dad7e0a13ea1ada028874cc4ebe585087f930bcb49027f85803
+  checksum: 10/90e34dc678e4ae57edff5769551bcf71f7ef1ee7cdcf0a091abb72cc1784ccd21d62f2ac99130b658cd7e2b464eeb5dd1000fdef48a27aa4d2c4674746e1e053
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates `semantic-release` to v25.0.9